### PR TITLE
Select providers more safely

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -192,9 +192,12 @@ end
 
 def providers
   if ENV['PROVIDERS'] == 'all'
-    ALLOWED_PROVIDERS
-  elsif ! ENV['PROVIDERS'].nil?
-    ENV['PROVIDERS'].split(',')
+    return ALLOWED_PROVIDERS
   end
-  ALLOWED_PROVIDERS
+
+  if not ENV['PROVIDERS'].nil?
+    return ENV['PROVIDERS']
+  end
+
+  raise 'Could not figure out which providers to deploy to.'
 end


### PR DESCRIPTION
Be more explicit about which providers we're selecting, and raise an error rather than returning all providers if we make it to the end of the method to fail safely.