### PR TITLE
Ensure providers method always returns array

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -196,7 +196,7 @@ def providers
   end
 
   if not ENV['PROVIDERS'].nil?
-    return ENV['PROVIDERS']
+    return [ENV['PROVIDERS']]
   end
 
   raise 'Could not figure out which providers to deploy to.'


### PR DESCRIPTION
We call `.each` on this method which means it always needs to return an array.