### PR TITLE
Replace '.' with '_' in DNS resources titles

### DIFF
--- a/templates/dyn.tf.erb
+++ b/templates/dyn.tf.erb
@@ -5,7 +5,7 @@ provider "dyn" {
 }
 
 <% records['records'].each_with_index do | record, index | %>
-resource "dyn_record" "<%= record['subdomain'] %>_<%= index %>" {
+resource "dyn_record" "<%= record['subdomain'].gsub('.', '_') %>_<%= index %>" {
   zone = "<%= ENV['DYN_ZONE_ID'] %>"
   name = "<%= record['subdomain'] %>"
   type = "<%= record['record_type'] %>"

--- a/templates/route53.tf.erb
+++ b/templates/route53.tf.erb
@@ -6,7 +6,7 @@ provider "aws" {
 
 
 <% records['records'].each_with_index do | record, index | %>
-resource "aws_route53_record" "<%= record['subdomain'] %>_<%= index %>" {
+resource "aws_route53_record" "<%= record['subdomain'].gsub('.', '_') %>_<%= index %>" {
   zone_id = "<%= ENV['ROUTE53_ZONE_ID'] %>"
   name = "<%= record['subdomain'] %>"
   type = "<%= record['record_type'] %>"


### PR DESCRIPTION
Terraform does not allow dots in its resource names so we replace
them with underscores.