### PR TITLE
DO NOT MERGE Store tfstate files separately for each DNS provider

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -97,16 +97,18 @@ desc 'Configure the remote state location'
 task configure_s3_state: [:validate_environment, :purge_remote_state] do
   # workaround until we can move everything in to project based layout
 
-  args = []
-  args << 'terraform remote config'
-  args << '-backend=s3'
-  args << '-backend-config="acl=private"'
-  args << "-backend-config='bucket=#{bucket_name}'"
-  args << '-backend-config="encrypt=true"'
-  args << "-backend-config='key=terraform.tfstate'"
-  args << "-backend-config='region=#{region}'"
+  providers.each { |provider|
+    args = []
+    args << 'terraform remote config'
+    args << '-backend=s3'
+    args << '-backend-config="acl=private"'
+    args << "-backend-config='bucket=#{bucket_name}'"
+    args << '-backend-config="encrypt=true"'
+    args << "-backend-config='key=#{provider}/terraform.tfstate'"
+    args << "-backend-config='region=#{region}'"
 
-  _run_system_command(args.join(' '))
+    _run_system_command(args.join(' '))
+  }
 end
 
 desc 'Apply the terraform resources'
@@ -183,7 +185,7 @@ def region
 end
 
 def bucket_name
-  ENV['BUCKET_NAME'] || 'govuk-terraform-dns-state-' + deploy_env
+  ENV['BUCKET_NAME'] || 'dns-state-bucket-' + deploy_env
 end
 
 def dry_run


### PR DESCRIPTION
We want to be able to deploy DNS to each provider separately from
the others. To enable this we store each terraform state file in its
own directory in the S3 bucket.

This relies on https://github.com/alphagov/govuk-terraform-provisioning/pull/95 to deploy the bucket