### PR TITLE
Refactor resource titles

### DIFF
--- a/templates/dyn.tf.erb
+++ b/templates/dyn.tf.erb
@@ -1,11 +1,12 @@
+<!-- TODO these shouldn't be embedded -->
 provider "dyn" {
   customer_name = "<%= ENV['DYN_CUSTOMER_NAME'] %>"
   username = "<%= ENV['DYN_USERNAME'] %>"
   password = "<%= ENV['DYN_PASSWORD'] %>"
 }
 
-<% records['records'].each_with_index do | record, index | %>
-resource "dyn_record" "<%= record['subdomain'].gsub('.', '_').gsub('@', 'AT') %>_<%= index %>" {
+<% records['records'].each do | record | %>
+resource "dyn_record" "<%= record['resource_title'] %>" {
   zone = "<%= ENV['DYN_ZONE_ID'] %>"
   name = "<%= record['subdomain'] %>"
   type = "<%= record['record_type'] %>"

--- a/templates/gce.tf.erb
+++ b/templates/gce.tf.erb
@@ -1,5 +1,5 @@
-<% records['records'].each_with_index do | record, index | %>
-resource "google_dns_record_set" "<%= record['subdomain'].gsub('.', '_').gsub('@', 'AT') %>_<%= index %>" {
+<% records['records'].each do | record | %>
+resource "google_dns_record_set" "<%= record['resource_title'] %>" {
   managed_zone = "<%= ENV['GOOGLE_MANAGED_ZONE'] %>"
   name = "<%= record['subdomain'] %>"
   type = "<%= record['record_type'] %>"

--- a/templates/route53.tf.erb
+++ b/templates/route53.tf.erb
@@ -1,12 +1,12 @@
+<!-- TODO these values shouldn't be embedded -->
 provider "aws" {
   access_key = "<%= ENV['AWS_ACCESS_KEY_ID'] %>"
   secret_key = "<%= ENV['AWS_SECRET_ACCESS_KEY'] %>"
   region = "<%= region %>"
 }
 
-
-<% records['records'].each_with_index do | record, index | %>
-resource "aws_route53_record" "<%= record['subdomain'].gsub('.', '_').gsub('@', 'AT') %>_<%= index %>" {
+<% records['records'].each do | record | %>
+resource "aws_route53_record" "<%= record['resource_title'] %>" {
   zone_id = "<%= ENV['ROUTE53_ZONE_ID'] %>"
   name = "<%= record['subdomain'] %>"
   type = "<%= record['record_type'] %>"


### PR DESCRIPTION
This changes us from using indexes to disambiguate resource titles to using a hash of the record's fields. This is to help reduce the likelihood of needlessly adding and removing records due to changes in the YAML.

It does mean that changing the data field for a record will make a new record.