### PR TITLE
Terraform validation fixes

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -83,17 +83,25 @@ end
 
 desc 'Apply the terraform resources'
 task apply: [:local_state_check, :validate_environment, :purge_remote_state] do
-  _run_terraform_cmd_for_providers("apply")
+  _run_terraform_cmd_for_providers('apply')
 end
 
 desc 'Destroy the terraform resources'
 task destroy: [:local_state_check, :validate_environment, :purge_remote_state] do
-  _run_terraform_cmd_for_providers("destroy")
+  _run_terraform_cmd_for_providers('destroy')
 end
 
 desc 'Show the plan'
 task plan: [:local_state_check, :validate_environment, :purge_remote_state] do
-  _run_terraform_cmd_for_providers("plan -module-depth=-1")
+  _run_terraform_cmd_for_providers('plan -module-depth=-1')
+end
+
+desc 'Validate the generated terraform'
+task :validate do
+  providers.each { |current_provider|
+    puts "Validating #{current_provider} terraform"
+    _run_system_command("terraform validate #{TMP_DIR}/#{current_provider}", true)
+  }
 end
 
 desc "Clean the temporary directory"
@@ -130,10 +138,13 @@ task generate: [:validate_generate_environment, :clean] do
     Dir.mkdir(provider_dir) unless File.exist?(provider_dir)
     File.write("#{provider_dir}/zone.tf", renderer.result(binding))
   }
+
+  Rake::Task['validate'].invoke
 end
 
-def _run_system_command(command)
-  if dry_run == true
+def _run_system_command(command, ignore_dry_run = false)
+  if dry_run == true && !ignore_dry_run
+    puts 'DRY_RUN'
     command = "echo #{command}"
   end
 

--- a/Rakefile
+++ b/Rakefile
@@ -128,6 +128,9 @@ task generate: [:validate_generate_environment, :clean] do
     md5 << rec['data']
     md5 << rec['record_type']
     rec['resource_title'] = "#{base_title}_#{md5.hexdigest}"
+    # Terraform requires escaped slashes in its strings.
+    # The 6 '\'s are required because of how gsub works (see https://www.ruby-forum.com/topic/143645)
+    rec['data'].gsub!('\\', '\\\\\\')
     rec
   }
 

--- a/templates/dyn.tf.erb
+++ b/templates/dyn.tf.erb
@@ -1,4 +1,4 @@
-<!-- TODO these shouldn't be embedded -->
+# TODO these shouldn't be embedded
 provider "dyn" {
   customer_name = "<%= ENV['DYN_CUSTOMER_NAME'] %>"
   username = "<%= ENV['DYN_USERNAME'] %>"

--- a/templates/route53.tf.erb
+++ b/templates/route53.tf.erb
@@ -1,4 +1,4 @@
-<!-- TODO these values shouldn't be embedded -->
+#  TODO these values shouldn't be embedded
 provider "aws" {
   access_key = "<%= ENV['AWS_ACCESS_KEY_ID'] %>"
   secret_key = "<%= ENV['AWS_SECRET_ACCESS_KEY'] %>"


### PR DESCRIPTION
This fixes a couple of bugs:

* Terraform requires escaped \ in its strings (which we weren't doing) otherwise it throws validation errors
* The comment style used in the templates was incorrect (as noted here https://github.com/alphagov/govuk-dns/pull/13#discussion_r103987360)

This also adds a `validation` task to Rake