### PR TITLE
Remove '@'s from GCE CloudDNS name fields.

### DIFF
--- a/lib/tasks/generate.rb
+++ b/lib/tasks/generate.rb
@@ -25,9 +25,11 @@ def _get_gce_resource(records)
     data = record_set.collect { |r| r['data'] }.sort
     title = _get_resource_title(subdomain, data, type)
 
+    record_name = subdomain == '@' ? "${var.GOOGLE_DNS_NAME}" : "#{subdomain}.${var.GOOGLE_DNS_NAME}"
+
     resource_hash[title] = {
       managed_zone: '${var.GOOGLE_ZONE_NAME}',
-      name: "#{subdomain}.${var.GOOGLE_DNS_NAME}",
+      name: record_name,
       type: type,
       ttl: record_set.collect { |r| r['ttl'] }.min,
       rrdatas: data,

--- a/lib/tasks/generate.rb
+++ b/lib/tasks/generate.rb
@@ -3,11 +3,11 @@ require 'digest'
 def _generate_terraform_object(provider, records, vars)
   case provider
   when 'gce'
-    resources = _get_gce_resource(records)
+    resources = { google_dns_record_set: _get_gce_resource(records) }
   when 'route53'
-    resources = _get_route53_resource(records)
+    resources = { aws_route53_record: _get_route53_resource(records) }
   when 'dyn'
-    resources = _get_dyn_resource(records)
+    resources = { dyn_record: _get_dyn_resource(records) }
   end
   {
     variable: _get_tf_variables(vars),
@@ -34,7 +34,7 @@ def _get_gce_resource(records)
     }
   }
 
-  { google_dns_record_set: resource_hash }
+  resource_hash
 end
 
 def _get_route53_resource(records)
@@ -51,7 +51,7 @@ def _get_route53_resource(records)
     }
   }
 
-  { aws_route53_record: resource_hash }
+  resource_hash
 end
 
 def _get_dyn_resource(records)
@@ -68,7 +68,7 @@ def _get_dyn_resource(records)
     }
   }
 
-  { dyn_record: resource_hash }
+  resource_hash
 end
 
 def _get_tf_variables(provider_variables)

--- a/spec/generate_spec.rb
+++ b/spec/generate_spec.rb
@@ -74,20 +74,18 @@ RSpec.describe 'generate' do
       records = [
         {
           'record_type' => 'NS',
-          'subdomain' => '@',
+          'subdomain' => 'test',
           'ttl' => '86400',
           'data' => 'example.com.',
         }
       ]
       expect = {
-        google_dns_record_set: {
-          'AT_4be974591aeffe148587193aac4d4b63' => {
-            managed_zone: '${var.GOOGLE_ZONE_NAME}',
-            name: '@.${var.GOOGLE_DNS_NAME}',
-            type: 'NS',
-            ttl: '86400',
-            rrdatas: ['example.com.'],
-          }
+        'test_236b5c05fab203a25167bb2bcac37372' => {
+          managed_zone: '${var.GOOGLE_ZONE_NAME}',
+          name: 'test.${var.GOOGLE_DNS_NAME}',
+          type: 'NS',
+          ttl: '86400',
+          rrdatas: ['example.com.'],
         }
       }
 
@@ -98,26 +96,24 @@ RSpec.describe 'generate' do
       records = [
         {
           'record_type' => 'NS',
-          'subdomain' => '@',
+          'subdomain' => 'test',
           'ttl' => '86400',
           'data' => 'example.com.',
         },
         {
           'record_type' => 'NS',
-          'subdomain' => '@',
+          'subdomain' => 'test',
           'ttl' => '86400',
           'data' => 'example2.com.',
         }
       ]
       expect = {
-        google_dns_record_set: {
-          'AT_5e340d3857c592022bb02576e7b16a3b' => {
-            managed_zone: '${var.GOOGLE_ZONE_NAME}',
-            name: '@.${var.GOOGLE_DNS_NAME}',
-            type: 'NS',
-            ttl: '86400',
-            rrdatas: ['example.com.', 'example2.com.'],
-          }
+        'test_51713ce0554bf6c6b40b5d47015cfce3' => {
+          managed_zone: '${var.GOOGLE_ZONE_NAME}',
+          name: 'test.${var.GOOGLE_DNS_NAME}',
+          type: 'NS',
+          ttl: '86400',
+          rrdatas: ['example.com.', 'example2.com.'],
         }
       }
 
@@ -136,14 +132,12 @@ RSpec.describe 'generate' do
         }
       ]
       expect = {
-        aws_route53_record: {
-          'AT_4be974591aeffe148587193aac4d4b63' => {
-            zone_id: '${var.ROUTE53_ZONE_ID}',
-            name: '@',
-            type: 'NS',
-            ttl: '86400',
-            records: ['example.com.'],
-          }
+        'AT_4be974591aeffe148587193aac4d4b63' => {
+          zone_id: '${var.ROUTE53_ZONE_ID}',
+          name: '@',
+          type: 'NS',
+          ttl: '86400',
+          records: ['example.com.'],
         }
       }
 
@@ -166,21 +160,19 @@ RSpec.describe 'generate' do
         }
       ]
       expect = {
-        aws_route53_record: {
-          'AT_4be974591aeffe148587193aac4d4b63' => {
-            zone_id: '${var.ROUTE53_ZONE_ID}',
-            name: '@',
-            type: 'NS',
-            ttl: '86400',
-            records: ['example.com.'],
-          },
-          'AT_1d8dc76cba0c12fb7e82e3141e3d45f7' => {
-            zone_id: '${var.ROUTE53_ZONE_ID}',
-            name: '@',
-            type: 'NS',
-            ttl: '86400',
-            records: ['example2.com.'],
-          }
+        'AT_4be974591aeffe148587193aac4d4b63' => {
+          zone_id: '${var.ROUTE53_ZONE_ID}',
+          name: '@',
+          type: 'NS',
+          ttl: '86400',
+          records: ['example.com.'],
+        },
+        'AT_1d8dc76cba0c12fb7e82e3141e3d45f7' => {
+          zone_id: '${var.ROUTE53_ZONE_ID}',
+          name: '@',
+          type: 'NS',
+          ttl: '86400',
+          records: ['example2.com.'],
         }
       }
 
@@ -199,14 +191,12 @@ RSpec.describe 'generate' do
         }
       ]
       expect = {
-        dyn_record: {
-          'AT_4be974591aeffe148587193aac4d4b63' => {
-            zone: '${var.DYN_ZONE_ID}',
-            name: '@',
-            type: 'NS',
-            ttl: '86400',
-            value: 'example.com.',
-          }
+        'AT_4be974591aeffe148587193aac4d4b63' => {
+          zone: '${var.DYN_ZONE_ID}',
+          name: '@',
+          type: 'NS',
+          ttl: '86400',
+          value: 'example.com.',
         }
       }
 
@@ -229,21 +219,19 @@ RSpec.describe 'generate' do
         }
       ]
       expect = {
-        dyn_record: {
-          'AT_4be974591aeffe148587193aac4d4b63' => {
-            zone: '${var.DYN_ZONE_ID}',
-            name: '@',
-            type: 'NS',
-            ttl: '86400',
-            value: 'example.com.',
-          },
-          'AT_1d8dc76cba0c12fb7e82e3141e3d45f7' => {
-            zone: '${var.DYN_ZONE_ID}',
-            name: '@',
-            type: 'NS',
-            ttl: '86400',
-            value: 'example2.com.',
-          }
+        'AT_4be974591aeffe148587193aac4d4b63' => {
+          zone: '${var.DYN_ZONE_ID}',
+          name: '@',
+          type: 'NS',
+          ttl: '86400',
+          value: 'example.com.',
+        },
+        'AT_1d8dc76cba0c12fb7e82e3141e3d45f7' => {
+          zone: '${var.DYN_ZONE_ID}',
+          name: '@',
+          type: 'NS',
+          ttl: '86400',
+          value: 'example2.com.',
         }
       }
 
@@ -252,7 +240,7 @@ RSpec.describe 'generate' do
   end
 
   describe '_generate_terraform_object' do
-    it 'should be side-effect free for all providers' do
+    it 'should be side-effect free for all providers and contain the correct resource' do
       records = [
         {
           'record_type' => 'NS',
@@ -280,6 +268,12 @@ RSpec.describe 'generate' do
         }.freeze,
       ].freeze
 
+      expected_resource_names = {
+          'gce'     => :google_dns_record_set,
+          'dyn'     => :dyn_record,
+          'route53' => :aws_route53_record,
+        }.freeze
+
       ALLOWED_PROVIDERS.each {|current_provider|
         vars = REQUIRED_ENV_VARS[current_provider.to_sym][:tf]
         result = nil
@@ -289,6 +283,7 @@ RSpec.describe 'generate' do
         }.to_not raise_error
 
         expect(result).to include(:resource, :variable)
+        expect(result[:resource]).to include(expected_resource_names[current_provider])
       }
     end
   end

--- a/spec/generate_spec.rb
+++ b/spec/generate_spec.rb
@@ -92,6 +92,21 @@ RSpec.describe 'generate' do
       expect(_get_gce_resource(records)).to eq(expect)
     end
 
+    it 'should not include the "@" in the name field' do
+      records = [
+        {
+          'record_type' => 'NS',
+          'subdomain' => '@',
+          'ttl' => '86400',
+          'data' => 'example.com.',
+        }
+      ]
+
+      result = _get_gce_resource(records)
+      expect(result['AT_4be974591aeffe148587193aac4d4b63'][:name]).to eq('${var.GOOGLE_DNS_NAME}')
+    end
+
+
     it 'should group records by subdomain and type' do
       records = [
         {


### PR DESCRIPTION
The GCE terraform resource expects the `name` field to contain the FQDN for the record rather than the normal `label` field used in BIND. This presents no problems in most cases except when deploying to the `$ORIGIN` using the `@` as this produces an invalid domain. This fixes this issue.