### PR TITLE
Remove default export

### DIFF
--- a/jenkins.sh
+++ b/jenkins.sh
@@ -14,8 +14,6 @@ case "$1" in
     exit 1
 esac
 
-export ZONEFILE=publishing.service.gov.uk.yaml
-
 git clone 'git@github.gds:gds/govuk-dns-config.git'
 
 cp govuk-dns-config/$ZONEFILE .


### PR DESCRIPTION
We can set this within the Jenkins job itself.

Story: https://trello.com/c/im16e5ue/447-create-a-way-to-sufficiently-test-the-deployment-of-dns-dns