### PR TITLE
Oddity bugfixes

### DIFF
--- a/lib/tasks/generate.rb
+++ b/lib/tasks/generate.rb
@@ -49,10 +49,12 @@ def _get_route53_resource(records)
     data = record_set.collect { |r| r['data'] }.sort
     title = _get_resource_title(subdomain, data, type)
 
+    record_name = subdomain == '@' ? "" : "#{subdomain}"
+
     #title = _get_resource_title(rec['subdomain'], [rec['data']], rec['record_type'])
     resource_hash[title] = {
       zone_id: '${var.ROUTE53_ZONE_ID}',
-      name: subdomain,
+      name: record_name,
       type: type,
       ttl: record_set.collect { |r| r['ttl'] }.min,
       records: data,

--- a/lib/tasks/generate.rb
+++ b/lib/tasks/generate.rb
@@ -42,14 +42,20 @@ end
 def _get_route53_resource(records)
   resource_hash = Hash.new
 
-  records.map { |rec|
-    title = _get_resource_title(rec['subdomain'], [rec['data']], rec['record_type'])
+  grouped_records = records.group_by { |rec| [rec['subdomain'], rec['record_type']] }
+
+  grouped_records.each { |subdomain_and_type, record_set|
+    subdomain, type = subdomain_and_type
+    data = record_set.collect { |r| r['data'] }.sort
+    title = _get_resource_title(subdomain, data, type)
+
+    #title = _get_resource_title(rec['subdomain'], [rec['data']], rec['record_type'])
     resource_hash[title] = {
       zone_id: '${var.ROUTE53_ZONE_ID}',
-      name: rec['subdomain'],
-      type: rec['record_type'],
-      ttl: rec['ttl'],
-      records: [rec['data']],
+      name: subdomain,
+      type: type,
+      ttl: record_set.collect { |r| r['ttl'] }.min,
+      records: data,
     }
   }
 

--- a/spec/generate_spec.rb
+++ b/spec/generate_spec.rb
@@ -149,7 +149,7 @@ RSpec.describe 'generate' do
       expect = {
         'AT_4be974591aeffe148587193aac4d4b63' => {
           zone_id: '${var.ROUTE53_ZONE_ID}',
-          name: '@',
+          name: '',
           type: 'NS',
           ttl: '86400',
           records: ['example.com.'],
@@ -159,7 +159,21 @@ RSpec.describe 'generate' do
       expect(_get_route53_resource(records)).to eq(expect)
     end
 
-    it 'should not group records' do
+    it 'should not include the "@" in the name field' do
+      records = [
+        {
+          'record_type' => 'NS',
+          'subdomain' => '@',
+          'ttl' => '86400',
+          'data' => 'example.com.',
+        }
+      ]
+
+      result = _get_route53_resource(records)
+      expect(result['AT_4be974591aeffe148587193aac4d4b63'][:name]).to eq('')
+    end
+
+    it 'should group records by subdomain and type' do
       records = [
         {
           'record_type' => 'NS',
@@ -175,19 +189,12 @@ RSpec.describe 'generate' do
         }
       ]
       expect = {
-        'AT_4be974591aeffe148587193aac4d4b63' => {
+        'AT_5e340d3857c592022bb02576e7b16a3b' => {
           zone_id: '${var.ROUTE53_ZONE_ID}',
-          name: '@',
+          name: '',
           type: 'NS',
           ttl: '86400',
-          records: ['example.com.'],
-        },
-        'AT_1d8dc76cba0c12fb7e82e3141e3d45f7' => {
-          zone_id: '${var.ROUTE53_ZONE_ID}',
-          name: '@',
-          type: 'NS',
-          ttl: '86400',
-          records: ['example2.com.'],
+          records: ['example.com.', 'example2.com.'],
         }
       }
 


### PR DESCRIPTION
A couple of bug fixes, please see detail in the commits.

I tested this in Integration for specific TXT records where I was having inconsistent results and managed to return a positive:
```
🐒  ~ ✗ dig TXT dns-test.integration.publishing.service.gov.uk @ns-647.awsdns-16.net. +short
"globalsign-domain-verification=INYQnRXIQfznLaHejAi-z4ZPb6W3Ez3H7BMdhfeAXx"
"google-site-verification=M5Q0yBeU28XdlP78DtIzUcc6m63GXzYS4Rrkf2Ab7Ng"
"v=spf1 -all"
🐒  ~ ✗ dig TXT dns-test.integration.publishing.service.gov.uk @ns-cloud-a1.googledomains.com. +short
"v=spf1 -all"
"google-site-verification=M5Q0yBeU28XdlP78DtIzUcc6m63GXzYS4Rrkf2Ab7Ng"
"globalsign-domain-verification=INYQnRXIQfznLaHejAi-z4ZPb6W3Ez3H7BMdhfeAXx"
```