### PR TITLE
Allow multiple statefile names

### DIFF
--- a/lib/tasks/common.rb
+++ b/lib/tasks/common.rb
@@ -33,6 +33,15 @@ def _check_for_missing_var(var, msg = "Please set the '#{var}' environment varia
   end
 end
 
+def statefile_name
+  if ENV['ZONEFILE'].nil?
+    return "terraform.tfstate"
+  else
+    # Statefile called publishing-service-gov-uk.tfstate
+    return ENV['ZONEFILE'].gsub('.yaml', '').gsub('.', '-') + ".tfstate"
+  end
+end
+
 def deploy_env
   ENV['DEPLOY_ENV']
 end

--- a/lib/tasks/terraform.rake
+++ b/lib/tasks/terraform.rake
@@ -99,7 +99,7 @@ def _run_terraform_cmd_for_providers(command)
     configure_state_cmd << '-backend-config="acl=private"'
     configure_state_cmd << "-backend-config='bucket=#{bucket_name}'"
     configure_state_cmd << '-backend-config="encrypt=true"'
-    configure_state_cmd << "-backend-config='key=#{current_provider}/terraform.tfstate'"
+    configure_state_cmd << "-backend-config='key=#{current_provider}/#{statefile_name}"
     configure_state_cmd << "-backend-config='region=#{region}'"
 
     _run_system_command(configure_state_cmd.join(' '))


### PR DESCRIPTION
We use the ZONEFILE env var in our deploy job. Use this to use a differently named statefile for terraform which would allow us to publish multiple zones. If we not do this, then terraform will probably overwrite everything.

This will require creating a copy of the current DNS records state file in S3 and testing.