### PR TITLE
Add single quote

### DIFF
--- a/lib/tasks/terraform.rake
+++ b/lib/tasks/terraform.rake
@@ -99,7 +99,7 @@ def _run_terraform_cmd_for_providers(command)
     configure_state_cmd << '-backend-config="acl=private"'
     configure_state_cmd << "-backend-config='bucket=#{bucket_name}'"
     configure_state_cmd << '-backend-config="encrypt=true"'
-    configure_state_cmd << "-backend-config='key=#{current_provider}/#{statefile_name}"
+    configure_state_cmd << "-backend-config='key=#{current_provider}/#{statefile_name}'"
     configure_state_cmd << "-backend-config='region=#{region}'"
 
     _run_system_command(configure_state_cmd.join(' '))


### PR DESCRIPTION
In my last commit I omitted a `'` character which caused the following
error:

sh: 1: Syntax error: Unterminated quoted string
rake aborted!