### PR TITLE
Allow wildcards in non-TXT records

### DIFF
--- a/lib/tasks/utilities/zone_file_field_validator.rb
+++ b/lib/tasks/utilities/zone_file_field_validator.rb
@@ -54,8 +54,9 @@ module ZoneFileFieldValidator
 
   def self.subdomain?(subdomain)
     return true if subdomain == '@' # Reference to $ORIGIN
-    # Allowed characters are numbers, lower-case letters, periods and hyphens
-    regex = /\A[-.a-z0-9]*\z/
+    # Allowed characters are numbers, lower-case letters, periods and hyphens per part
+    # Wildcard character (*) is only allowed on its own in the least significant part
+    regex = /\A(\*\.)?[-.a-z0-9]*\z|\A\*\z/
     !!(regex =~ subdomain)
   end
 
@@ -142,7 +143,7 @@ module ZoneFileFieldValidator
     elsif type == 'TXT' && ! txt_subdomain?(subdomain)
       errors << "Invalid TXT subdomain field, must either be '@' or consist of numbers, letters, hyphens, periods and underscores; got: '#{subdomain}'."
     elsif type != 'TXT' && ! subdomain?(subdomain)
-      errors << "Invalid #{type} subdomain field, must either be '@' or consist of numbers, letters, hyphens, and periods; got: '#{subdomain}'."
+      errors << "Invalid #{type} subdomain field, must either be '@' or consist of numbers, letters, hyphens, periods, and wildcards; got: '#{subdomain}'."
     end
 
     errors

--- a/spec/validate_yaml_spec.rb
+++ b/spec/validate_yaml_spec.rb
@@ -99,6 +99,12 @@ RSpec.describe 'Zone file field validators' do
       expect(ZoneFileFieldValidator.subdomain?('dotted.example')).to be true
     end
 
+    it 'should be true for wildcards' do
+      expect(ZoneFileFieldValidator.subdomain?('*')).to be true
+      expect(ZoneFileFieldValidator.subdomain?('*.foo')).to be true
+      expect(ZoneFileFieldValidator.subdomain?('*.foo.bar')).to be true
+    end
+
     it 'should be false for strings that contain underscores' do
       expect(ZoneFileFieldValidator.subdomain?('bad_example')).to be false
     end
@@ -109,6 +115,17 @@ RSpec.describe 'Zone file field validators' do
 
     it 'should be false for strings that contain uppercase' do
       expect(ZoneFileFieldValidator.subdomain?('BAD_EXAMPLE')).to be false
+    end
+
+    it 'should be false for strings that contain asterisks' do
+      expect(ZoneFileFieldValidator.subdomain?('something*')).to be false
+      expect(ZoneFileFieldValidator.subdomain?('*something')).to be false
+      expect(ZoneFileFieldValidator.subdomain?('some*thing')).to be false
+    end
+
+    it 'should be false for wildcards anywhere but the least significant part' do
+      expect(ZoneFileFieldValidator.subdomain?('some.*.thing')).to be false
+      expect(ZoneFileFieldValidator.subdomain?('thing.*')).to be false
     end
   end
 


### PR DESCRIPTION
We need to CNAME a wildcard subdomain to Heroku. This change permits
adding wildcard records but only at the least significant part of the
record.