### PR TITLE
Make wildcard records safe to use in TF titles

### DIFF
--- a/lib/tasks/utilities/generate.rb
+++ b/lib/tasks/utilities/generate.rb
@@ -109,5 +109,5 @@ end
 
 def _get_tf_safe_title(title)
   # Terraform resource records cannot contain '.'s or '@'s
-  title.tr('.', '_').gsub(/@/, 'AT')
+  title.tr('.', '_').gsub(/@/, 'AT').gsub('*', 'WILDCARD')
 end

--- a/spec/generate_spec.rb
+++ b/spec/generate_spec.rb
@@ -11,6 +11,10 @@ RSpec.describe 'generate' do
       expect(_get_tf_safe_title('foo.bar')).to eq('foo_bar')
     end
 
+    it 'should replace "*"s with "WILDCARD"s' do
+      expect(_get_tf_safe_title('*.bar')).to eq('WILDCARD_bar')
+    end
+
     it 'should not change other titles' do
       expect(_get_tf_safe_title('unchanged')).to eq('unchanged')
     end


### PR DESCRIPTION
Replace `*` with `WILDCARD` in titles