### PR TITLE
Allow underscores on CNAME subdomains

### DIFF
--- a/lib/tasks/utilities/zone_file_field_validator.rb
+++ b/lib/tasks/utilities/zone_file_field_validator.rb
@@ -56,7 +56,7 @@ module ZoneFileFieldValidator
     return true if subdomain == '@' # Reference to $ORIGIN
     # Allowed characters are numbers, lower-case letters, periods and hyphens per part
     # Wildcard character (*) is only allowed on its own in the least significant part
-    regex = /\A(\*\.)?[-.a-z0-9]*\z|\A\*\z/
+    regex = /\A(\*\.)?[-_.a-z0-9]*\z|\A\*\z/
     !!(regex =~ subdomain)
   end
 

--- a/spec/validate_yaml_spec.rb
+++ b/spec/validate_yaml_spec.rb
@@ -105,8 +105,8 @@ RSpec.describe 'Zone file field validators' do
       expect(ZoneFileFieldValidator.subdomain?('*.foo.bar')).to be true
     end
 
-    it 'should be false for strings that contain underscores' do
-      expect(ZoneFileFieldValidator.subdomain?('bad_example')).to be false
+    it 'should be true for strings that contain underscores' do
+      expect(ZoneFileFieldValidator.subdomain?('bad_example')).to be true
     end
 
     it 'should be false for strings that contain @ in addition to other things' do


### PR DESCRIPTION
I need underscores to validate an SSL certificate, so let's accept that this is an OK format to create a DNS for.