### PR TITLE
Set `@` symbol if subdomain matches origin

### DIFF
--- a/lib/tasks/import_bind.rake
+++ b/lib/tasks/import_bind.rake
@@ -25,11 +25,17 @@ task :import_bind do
     # Skip the SOA
     next if record.type == 'SOA'
 
+    if record.label == zone.origin
+      subdomain = '@'
+    else
+      subdomain = record.label
+    end
+
     # Records inherit fields for a parent Record object, we explicitly read
     # the fields as we cannot extract them with the instance_variables method
     record_hash = {
       'record_type' => record.type,
-      'subdomain' => record.label,
+      'subdomain' => subdomain,
       'ttl' => record.ttl,
     }
 

--- a/lib/tasks/import_bind.rake
+++ b/lib/tasks/import_bind.rake
@@ -25,6 +25,10 @@ task :import_bind do
     # Skip the SOA
     next if record.type == 'SOA'
 
+    if record.label == zone.origin || record.label == "@"
+      next if record.type == 'NS'
+    end
+
     if record.label == zone.origin
       subdomain = '@'
     else


### PR DESCRIPTION
When reviewing [this PR](https://github.com/alphagov/govuk-dns-config/pull/13) I noted that subdomains were being set as the full origin name when using the root domain. For example, if the origin is `example.com`, and there was an NS record for the root domain, then it was setting the subdomain also as `example.com`.

While technically correct due to the trailing dot, I believe it is not as clear to read, and is inconsistent with how we have set up our configuration for the zone already in use [ref](https://github.com/alphagov/govuk-dns-config/blob/master/publishing.service.gov.uk.yaml#L4-L7).

This also adds a commit which skips adding `NS` records if they are for the root domain due to the complications involved in trying to manage these when they are pre-generated by the DNS provider.