### PR TITLE
Read from config file rather than env vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Terraform resources can then be created in `tf-tmp` for your providers using:
 $ ZONEFILE=zonefile.yaml PROVIDERS=<dns provider> bundle exec rake generate_terraform
 ```
 
-Where `<dns provider>` is one of 'gce', 'route53' or 'all'.
+Where `<dns provider>` is one of 'gcp', 'route53' or 'all'.
 
 This terraform can then be planned and applied using:
 ```bash
@@ -123,7 +123,7 @@ Given a YAML zonefile produce Terraform JSON for each specified provider. The pr
 ### Providers ###
 
 * `all` - Special value, uses all available providers.
-* `gce` - [Google's Cloud DNS](https://cloud.google.com/dns/docs/)
+* `gcp` - [Google's Cloud DNS](https://cloud.google.com/dns/docs/)
 * `route53` - [AWS' Route53](https://aws.amazon.com/route53)
 
 ## Terraform ##
@@ -188,7 +188,7 @@ The YAML Zonefile has the following format:
 origin: example.com.
 
 deployment:
-  gce:
+  gcp:
     zone_name: 'my-google-zone'
     dns_name: 'google.zone'
   aws:

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Terraform resources can then be created in `tf-tmp` for your providers using:
 $ ZONEFILE=zonefile.yaml PROVIDERS=<dns provider> bundle exec rake generate_terraform
 ```
 
-Where `<dns provider>` is one of 'dyn', 'gce', 'route53' or 'all'.
+Where `<dns provider>` is one of 'gce', 'route53' or 'all'.
 
 This terraform can then be planned and applied using:
 ```bash
@@ -40,10 +40,6 @@ $ export PROVIDERS=<provider>
 $ export DEPLOY_ENV=<production, staging or integration>
 $ export AWS_ACCESS_KEY_ID=<some secret>
 $ export AWS_SECRET_ACCESS_KEY=<some secret>
-$ export DYN_ZONE_ID=<dyn zone id>
-$ export DYN_USERNAME=<dyn username>
-$ export DYN_PASSWORD=<dyn password>
-$ export DYN_CUSTOMER_NAME=<dyn customer name>
 $ bundle exec rake tf:plan
 ...
 $ bundle exec rake tf:apply
@@ -52,7 +48,7 @@ $ bundle exec rake tf:apply
 
 **It is strongly recommended you always run `tf:plan` before `tf:apply`**
 
-Some of these environment variables are provider specific (in this example the provider is Dyn). It is important to note that the AWS key and secret are required regardless as these are used to store the remote state. Please check [this section](#per-provider-environment-variables) for the specific variables your provider needs.
+Some of these environment variables are provider specific. It is important to note that the AWS key and secret are required regardless as these are used to store the remote state. Please check [this section](#per-provider-environment-variables) for the specific variables your provider needs.
 
 In addition to these core tools there are several more that we use regularly:
 ```bash
@@ -127,7 +123,6 @@ Given a YAML zonefile produce Terraform JSON for each specified provider. The pr
 ### Providers ###
 
 * `all` - Special value, uses all available providers.
-* `dyn` - [Dyn](https://dyn.com/)
 * `gce` - [Google's Cloud DNS](https://cloud.google.com/dns/docs/)
 * `route53` - [AWS' Route53](https://aws.amazon.com/route53)
 
@@ -151,18 +146,9 @@ Other than `tf:validate` the Terraform tasks all share a number of options (`tf:
 * `AWS_DEFAULT_REGION` - Which region the S3 bucket is in. Default: `eu-west-1`
 * `BUCKET_NAME` - Name of the S3 bucket. Default: `dns-state-bucket-<environment>`, `environment` is set by DEPLOY_ENV.
 
-### Per provider environment variables ###
+### Google Cloud specific environment variables ###
 
-The specific providers each have specific variables that must be set
-
-#### Dyn ####
-
-* `DYN_ZONE_ID` - which zone to deploy to
-* `DYN_USERNAME` - specific user with permissions to deploy
-* `DYN_PASSWORD` - their password
-* `DYN_CUSTOMER_NAME` - customer account to access
-
-#### GCE ####
+Along with the environment variables set above, when deploying to Google the following must also be set:
 
 * `GOOGLE_DNS_NAME` - The DNS domain that will be deployed to (e.g. `example.com.`, GCE needs fully qualified domain names for its entries).
 * `GOOGLE_ZONE_NAME` - name of the hosted zone.

--- a/README.md
+++ b/README.md
@@ -139,6 +139,8 @@ A set of wrappers for standard Terraform commands. These wrappers store state in
 
 Other than `tf:validate` the Terraform tasks all share a number of options (`tf:validate` which only needs `PROVIDERS`).
 
+We use S3 as a backend for Terraform state, so AWS credentials are always required even when deploying to Google Cloud.
+
 * `PROVIDERS` (required) - see [above](#providers).
 * `DEPLOY_ENV` (required) - where to deploy to, one of `production`, `staging` or `integration`.
 * `AWS_ACCESS_KEY_ID` (required) - Access key with permissions for the bucket.
@@ -150,15 +152,9 @@ Other than `tf:validate` the Terraform tasks all share a number of options (`tf:
 
 Along with the environment variables set above, when deploying to Google the following must also be set:
 
-* `GOOGLE_DNS_NAME` - The DNS domain that will be deployed to (e.g. `example.com.`, GCE needs fully qualified domain names for its entries).
-* `GOOGLE_ZONE_NAME` - name of the hosted zone.
 * `GOOGLE_PROJECT` - project ID
 * `GOOGLE_REGION` - project region
 * `GOOGLE_CREDENTIALS` - JSON credentials for the service account to deploy using (best set using `GOOGLE_CREDENTIALS=$(cat <path to credentials>`).
-
-#### Route 53 ####
-
-* `ROUTE53_ZONE_ID` - which zone to deploy to.
 
 ## Testing ##
 
@@ -190,6 +186,14 @@ The YAML Zonefile has the following format:
 
 ```yaml
 origin: example.com.
+
+deployment:
+  gce:
+    zone_name: 'my-google-zone'
+    dns_name: 'google.zone'
+  aws:
+    zone_id: 'SOMEROUTE53ZONEID'
+
 records:
 - record_type: TXT
   subdomain: "@"
@@ -198,9 +202,21 @@ records:
 ...
 ```
 
+### Origin
+
+The root name of the zone. This allows upstream validation of the deployed DNS.
+
+### Deployment
+
+This sets the options required for deployment. These details may be sensitive, so be aware
+when setting them in the file. These details are used by Terraform to make changes to the
+correct upstream hosted zone.
+
+### Records
+
 `record_type` should be one of:
 
-* A 
+* A
 * NS
 * MX
 * TXT

--- a/README.md
+++ b/README.md
@@ -123,8 +123,8 @@ Given a YAML zonefile produce Terraform JSON for each specified provider. The pr
 ### Providers ###
 
 * `all` - Special value, uses all available providers.
-* `gcp` - [Google's Cloud DNS](https://cloud.google.com/dns/docs/)
-* `aws` - [AWS' Route53](https://aws.amazon.com/aws)
+* `gcp` - [Google Cloud DNS](https://cloud.google.com/dns/docs/)
+* `aws` - [AWS Route 53](https://aws.amazon.com/aws)
 
 ## Terraform ##
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Terraform resources can then be created in `tf-tmp` for your providers using:
 $ ZONEFILE=zonefile.yaml PROVIDERS=<dns provider> bundle exec rake generate_terraform
 ```
 
-Where `<dns provider>` is one of 'gcp', 'route53' or 'all'.
+Where `<dns provider>` is one of 'gcp', 'aws' or 'all'.
 
 This terraform can then be planned and applied using:
 ```bash
@@ -124,7 +124,7 @@ Given a YAML zonefile produce Terraform JSON for each specified provider. The pr
 
 * `all` - Special value, uses all available providers.
 * `gcp` - [Google's Cloud DNS](https://cloud.google.com/dns/docs/)
-* `route53` - [AWS' Route53](https://aws.amazon.com/route53)
+* `aws` - [AWS' Route53](https://aws.amazon.com/aws)
 
 ## Terraform ##
 

--- a/Rakefile
+++ b/Rakefile
@@ -8,8 +8,7 @@ end
 
 RSpec::Core::RakeTask.new(:validate_dns) do |t|
   if !File.exist?(zonefile)
-    warn "Zonefile, #{zonefile}, not found."
-    exit 1
+    abort("Zonefile, #{zonefile}, not found.")
   end
   t.rspec_opts = ['--tag', 'validate_dns']
 end

--- a/lib/tasks/generate_terraform.rake
+++ b/lib/tasks/generate_terraform.rake
@@ -16,13 +16,18 @@ task :generate_terraform do
     FileUtils.rm files
   end
 
-  # Load what we want
-  records = YAML.load(File.read(zonefile))['records']
+  # Load configuration
+  config_file = YAML.load_file(zonefile)
+  records = config_file['records']
+  deployment = config_file['deployment']
 
   # Render all the expected files
   providers.each { |current_provider|
-    tf_vars = REQUIRED_ENV_VARS[current_provider.to_sym][:tf]
-    out = generate_terraform_object(current_provider, records, tf_vars)
+    abort("Must set deployment options in configuration file") if deployment[current_provider.to_sym].empty?
+
+    deploy_vars = deployment[current_provider.to_sym]
+
+    out = generate_terraform_object(current_provider, records, deploy_vars)
 
     provider_dir = "#{TMP_DIR}/#{current_provider}"
     Dir.mkdir(provider_dir) unless File.exist?(provider_dir)

--- a/lib/tasks/terraform.rake
+++ b/lib/tasks/terraform.rake
@@ -62,8 +62,7 @@ def _local_state_check
   state_file = 'terraform.tfstate'
 
   if File.exist? state_file
-    warn 'Local state file should not exist. We use remote state files.'
-    exit 1
+    abort('Local state file should not exist. We use remote state files.')
   end
 end
 
@@ -73,8 +72,7 @@ def _purge_remote_state
   FileUtils.rm state_file if File.exist? state_file
 
   if File.exist? state_file
-    warn 'state file should not exist.'
-    exit 1
+    abort("State file should not exist: #{state_file}")
   end
 end
 
@@ -82,8 +80,7 @@ def _validate_terraform_environment
   allowed_envs = %w(test staging integration production)
 
   unless allowed_envs.include?(deploy_env)
-    warn "Please set 'DEPLOY_ENV' environment variable to one of #{allowed_envs.join(', ')}"
-    exit 1
+    abort("Please set 'DEPLOY_ENV' environment variable to one of #{allowed_envs.join(', ')}")
   end
 
   ENV['AWS_DEFAULT_REGION'] = ENV['AWS_DEFAULT_REGION'] || region

--- a/lib/tasks/terraform.rake
+++ b/lib/tasks/terraform.rake
@@ -116,3 +116,11 @@ def _check_terraform_version
     exit 1
   end
 end
+
+def _run_system_command(command)
+  if ENV['VERBOSE']
+    puts "#{command}"
+  end
+
+  abort("#{command} failed") unless system(command)
+end

--- a/lib/tasks/utilities/common.rb
+++ b/lib/tasks/utilities/common.rb
@@ -1,10 +1,6 @@
 TMP_DIR = 'tf-tmp'.freeze
 
 REQUIRED_ENV_VARS = {
-  dyn: {
-    tf:  %w{DYN_ZONE_ID}.freeze,
-    env: %w{DYN_CUSTOMER_NAME DYN_PASSWORD DYN_USERNAME}.freeze,
-  }.freeze,
   gce: {
     tf:  %w{GOOGLE_ZONE_NAME GOOGLE_DNS_NAME}.freeze,
     env: %w{GOOGLE_CREDENTIALS GOOGLE_REGION GOOGLE_PROJECT}.freeze,

--- a/lib/tasks/utilities/common.rb
+++ b/lib/tasks/utilities/common.rb
@@ -6,7 +6,7 @@ REQUIRED_ENV_VARS = {
   gcp: {
     env: %w{GOOGLE_CREDENTIALS GOOGLE_REGION GOOGLE_PROJECT}.freeze,
   }.freeze,
-  route53: {
+  aws: {
     env: %w{AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY AWS_DEFAULT_REGION}.freeze,
   }.freeze,
 }.freeze

--- a/lib/tasks/utilities/common.rb
+++ b/lib/tasks/utilities/common.rb
@@ -1,12 +1,12 @@
+require 'yaml'
+
 TMP_DIR = 'tf-tmp'.freeze
 
 REQUIRED_ENV_VARS = {
   gce: {
-    tf:  %w{GOOGLE_ZONE_NAME GOOGLE_DNS_NAME}.freeze,
     env: %w{GOOGLE_CREDENTIALS GOOGLE_REGION GOOGLE_PROJECT}.freeze,
   }.freeze,
   route53: {
-    tf:  %w{ROUTE53_ZONE_ID}.freeze,
     env: %w{AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY AWS_DEFAULT_REGION}.freeze,
   }.freeze,
 }.freeze

--- a/lib/tasks/utilities/common.rb
+++ b/lib/tasks/utilities/common.rb
@@ -1,16 +1,3 @@
-def _run_system_command(command)
-  if ENV['VERBOSE']
-    puts "#{command}"
-  end
-
-  system(command)
-  exit_code = $?.exitstatus
-
-  if exit_code.nonzero?
-    raise "Running '#{command}' failed with code #{exit_code}"
-  end
-end
-
 TMP_DIR = 'tf-tmp'.freeze
 
 REQUIRED_ENV_VARS = {

--- a/lib/tasks/utilities/common.rb
+++ b/lib/tasks/utilities/common.rb
@@ -3,7 +3,7 @@ require 'yaml'
 TMP_DIR = 'tf-tmp'.freeze
 
 REQUIRED_ENV_VARS = {
-  gce: {
+  gcp: {
     env: %w{GOOGLE_CREDENTIALS GOOGLE_REGION GOOGLE_PROJECT}.freeze,
   }.freeze,
   route53: {

--- a/lib/tasks/utilities/common.rb
+++ b/lib/tasks/utilities/common.rb
@@ -19,8 +19,7 @@ ALLOWED_PROVIDERS = REQUIRED_ENV_VARS.keys.map(&:to_s).freeze
 
 def required_from_env(var, msg = "Please set the '#{var}' environment variable.")
   unless ENV.include?(var)
-    warn msg
-    exit 1
+    abort(msg)
   end
   ENV[var]
 end
@@ -60,6 +59,5 @@ def providers
     return [ENV['PROVIDERS']]
   end
 
-  warn "Please set the 'PROVIDERS' environment variable to one of: #{ALLOWED_PROVIDERS.join(', ')} or all"
-  exit 1
+  abort("Please set the 'PROVIDERS' environment variable to one of: #{ALLOWED_PROVIDERS.join(', ')} or all")
 end

--- a/lib/tasks/utilities/generate.rb
+++ b/lib/tasks/utilities/generate.rb
@@ -2,8 +2,8 @@ require 'digest'
 
 def generate_terraform_object(provider, records, deployment_config)
   case provider
-  when 'gce'
-    resources = { google_dns_record_set: _get_gce_resource(records, deployment_config) }
+  when 'gcp'
+    resources = { google_dns_record_set: _get_gcp_resource(records, deployment_config) }
   when 'route53'
     resources = { aws_route53_record: _get_route53_resource(records, deployment_config) }
   end
@@ -12,7 +12,7 @@ def generate_terraform_object(provider, records, deployment_config)
   }
 end
 
-def _get_gce_resource(records, deployment_config)
+def _get_gcp_resource(records, deployment_config)
   resource_hash = Hash.new
 
   grouped_records = records.group_by { |rec| [rec['subdomain'], rec['record_type']] }

--- a/lib/tasks/utilities/generate.rb
+++ b/lib/tasks/utilities/generate.rb
@@ -4,8 +4,8 @@ def generate_terraform_object(provider, records, deployment_config)
   case provider
   when 'gcp'
     resources = { google_dns_record_set: _get_gcp_resource(records, deployment_config) }
-  when 'route53'
-    resources = { aws_route53_record: _get_route53_resource(records, deployment_config) }
+  when 'aws'
+    resources = { aws_route53_record: _get_aws_resource(records, deployment_config) }
   end
   {
     resource: resources,
@@ -36,7 +36,7 @@ def _get_gcp_resource(records, deployment_config)
   resource_hash
 end
 
-def _get_route53_resource(records, deployment_config)
+def _get_aws_resource(records, deployment_config)
   resource_hash = Hash.new
 
   grouped_records = records.group_by { |rec| [rec['subdomain'], rec['record_type']] }

--- a/lib/tasks/utilities/generate.rb
+++ b/lib/tasks/utilities/generate.rb
@@ -1,19 +1,18 @@
 require 'digest'
 
-def generate_terraform_object(provider, records, vars)
+def generate_terraform_object(provider, records, deployment_config)
   case provider
   when 'gce'
-    resources = { google_dns_record_set: _get_gce_resource(records) }
+    resources = { google_dns_record_set: _get_gce_resource(records, deployment_config) }
   when 'route53'
-    resources = { aws_route53_record: _get_route53_resource(records) }
+    resources = { aws_route53_record: _get_route53_resource(records, deployment_config) }
   end
   {
-    variable: _get_tf_variables(vars),
     resource: resources,
   }
 end
 
-def _get_gce_resource(records)
+def _get_gce_resource(records, deployment_config)
   resource_hash = Hash.new
 
   grouped_records = records.group_by { |rec| [rec['subdomain'], rec['record_type']] }
@@ -23,10 +22,10 @@ def _get_gce_resource(records)
     data = record_set.collect { |r| r['data'] }.sort
     title = _get_resource_title(subdomain, data, type)
 
-    record_name = subdomain == '@' ? "${var.GOOGLE_DNS_NAME}" : "#{subdomain}.${var.GOOGLE_DNS_NAME}"
+    record_name = subdomain == '@' ? deployment_config['dns_name'] : "#{subdomain}.#{deployment_config['dns_name']}"
 
     resource_hash[title] = {
-      managed_zone: '${var.GOOGLE_ZONE_NAME}',
+      managed_zone: deployment_config['zone_name'],
       name: record_name,
       type: type,
       ttl: record_set.collect { |r| r['ttl'] }.min,
@@ -37,7 +36,7 @@ def _get_gce_resource(records)
   resource_hash
 end
 
-def _get_route53_resource(records)
+def _get_route53_resource(records, deployment_config)
   resource_hash = Hash.new
 
   grouped_records = records.group_by { |rec| [rec['subdomain'], rec['record_type']] }
@@ -50,7 +49,7 @@ def _get_route53_resource(records)
     record_name = subdomain == '@' ? "" : subdomain.to_s
 
     resource_hash[title] = {
-      zone_id: '${var.ROUTE53_ZONE_ID}',
+      zone_id: deployment_config['zone_id'],
       name: record_name,
       type: type,
       ttl: record_set.collect { |r| r['ttl'] }.min,
@@ -59,11 +58,6 @@ def _get_route53_resource(records)
   }
 
   resource_hash
-end
-
-def _get_tf_variables(provider_variables)
-  # Produce a hash with keys set to the variables passed in
-  Hash[provider_variables.map { |var| [var, {}] }]
 end
 
 def _get_tf_safe_data(data)

--- a/lib/tasks/utilities/generate.rb
+++ b/lib/tasks/utilities/generate.rb
@@ -6,8 +6,6 @@ def generate_terraform_object(provider, records, vars)
     resources = { google_dns_record_set: _get_gce_resource(records) }
   when 'route53'
     resources = { aws_route53_record: _get_route53_resource(records) }
-  when 'dyn'
-    resources = { dyn_record: _get_dyn_resource(records) }
   end
   {
     variable: _get_tf_variables(vars),
@@ -57,23 +55,6 @@ def _get_route53_resource(records)
       type: type,
       ttl: record_set.collect { |r| r['ttl'] }.min,
       records: data,
-    }
-  }
-
-  resource_hash
-end
-
-def _get_dyn_resource(records)
-  resource_hash = Hash.new
-
-  records.map { |rec|
-    title = _get_resource_title(rec['subdomain'], [rec['data']], rec['record_type'])
-    resource_hash[title] = {
-      zone: '${var.DYN_ZONE_ID}',
-      name: rec['subdomain'],
-      type: rec['record_type'],
-      ttl: rec['ttl'],
-      value: rec['data'],
     }
   }
 

--- a/spec/generate_spec.rb
+++ b/spec/generate_spec.rb
@@ -206,65 +206,6 @@ RSpec.describe 'generate' do
     end
   end
 
-  describe '_get_dyn_resource' do
-    it 'should produce an object which matches the dyn terraform resource' do
-      records = [
-        {
-          'record_type' => 'NS',
-          'subdomain' => '@',
-          'ttl' => '86400',
-          'data' => 'example.com.',
-        }
-      ]
-      expect = {
-        'AT_4be974591aeffe148587193aac4d4b63' => {
-          zone: '${var.DYN_ZONE_ID}',
-          name: '@',
-          type: 'NS',
-          ttl: '86400',
-          value: 'example.com.',
-        }
-      }
-
-      expect(_get_dyn_resource(records)).to eq(expect)
-    end
-
-    it 'should not group records' do
-      records = [
-        {
-          'record_type' => 'NS',
-          'subdomain' => '@',
-          'ttl' => '86400',
-          'data' => 'example.com.',
-        },
-        {
-          'record_type' => 'NS',
-          'subdomain' => '@',
-          'ttl' => '86400',
-          'data' => 'example2.com.',
-        }
-      ]
-      expect = {
-        'AT_4be974591aeffe148587193aac4d4b63' => {
-          zone: '${var.DYN_ZONE_ID}',
-          name: '@',
-          type: 'NS',
-          ttl: '86400',
-          value: 'example.com.',
-        },
-        'AT_1d8dc76cba0c12fb7e82e3141e3d45f7' => {
-          zone: '${var.DYN_ZONE_ID}',
-          name: '@',
-          type: 'NS',
-          ttl: '86400',
-          value: 'example2.com.',
-        }
-      }
-
-      expect(_get_dyn_resource(records)).to eq(expect)
-    end
-  end
-
   describe '_generate_terraform_object' do
     it 'should be side-effect free for all providers and contain the correct resource' do
       records = [
@@ -296,7 +237,6 @@ RSpec.describe 'generate' do
 
       expected_resource_names = {
           'gce'     => :google_dns_record_set,
-          'dyn'     => :dyn_record,
           'route53' => :aws_route53_record,
         }.freeze
 

--- a/spec/generate_spec.rb
+++ b/spec/generate_spec.rb
@@ -63,8 +63,8 @@ RSpec.describe 'generate' do
     end
   end
 
-  describe '_get_gce_resource' do
-    it 'should produce an object which matches the gce cloudDNS terraform resource' do
+  describe '_get_gcp_resource' do
+    it 'should produce an object which matches the gcp cloudDNS terraform resource' do
       deployment = {
         'zone_name' => 'my-google-zone',
         'dns_name'  => 'my.dnsname.com'
@@ -87,7 +87,7 @@ RSpec.describe 'generate' do
         }
       }
 
-      expect(_get_gce_resource(records, deployment)).to eq(expect)
+      expect(_get_gcp_resource(records, deployment)).to eq(expect)
     end
 
     it 'should not include the "@" in the name field' do
@@ -104,7 +104,7 @@ RSpec.describe 'generate' do
         }
       ]
 
-      result = _get_gce_resource(records, deployment)
+      result = _get_gcp_resource(records, deployment)
       expect(result['AT_4be974591aeffe148587193aac4d4b63'][:name]).to eq('my.dnsname.com')
     end
 
@@ -138,7 +138,7 @@ RSpec.describe 'generate' do
         }
       }
 
-      expect(_get_gce_resource(records, deployment)).to eq(expect)
+      expect(_get_gcp_resource(records, deployment)).to eq(expect)
     end
   end
 
@@ -241,7 +241,7 @@ RSpec.describe 'generate' do
       ].freeze
 
       deployment = {
-        'gce' => {
+        'gcp' => {
           'zone_name' => 'my-google-zone',
           'dns_name'  => 'my.dnsname.com'
         },
@@ -251,7 +251,7 @@ RSpec.describe 'generate' do
       }
 
       expected_resource_names = {
-          'gce'     => :google_dns_record_set,
+          'gcp'     => :google_dns_record_set,
           'route53' => :aws_route53_record,
         }.freeze
 

--- a/spec/generate_spec.rb
+++ b/spec/generate_spec.rb
@@ -142,7 +142,7 @@ RSpec.describe 'generate' do
     end
   end
 
-  describe '_get_route53_resource' do
+  describe '_get_aws_resource' do
     it 'should produce an object which matches the route53 terraform resource' do
       deployment = { 'zone_id' => 'route53zoneid' }
       records = [
@@ -163,7 +163,7 @@ RSpec.describe 'generate' do
         }
       }
 
-      expect(_get_route53_resource(records, deployment)).to eq(expect)
+      expect(_get_aws_resource(records, deployment)).to eq(expect)
     end
 
     it 'should not include the "@" in the name field' do
@@ -177,7 +177,7 @@ RSpec.describe 'generate' do
         }
       ]
 
-      result = _get_route53_resource(records, deployment)
+      result = _get_aws_resource(records, deployment)
       expect(result['AT_4be974591aeffe148587193aac4d4b63'][:name]).to eq('')
     end
 
@@ -207,7 +207,7 @@ RSpec.describe 'generate' do
         }
       }
 
-      expect(_get_route53_resource(records, deployment)).to eq(expect)
+      expect(_get_aws_resource(records, deployment)).to eq(expect)
     end
   end
 
@@ -251,8 +251,8 @@ RSpec.describe 'generate' do
       }
 
       expected_resource_names = {
-          'gcp'     => :google_dns_record_set,
-          'route53' => :aws_route53_record,
+          'gcp' => :google_dns_record_set,
+          'aws' => :aws_route53_record,
         }.freeze
 
       ALLOWED_PROVIDERS.each { |current_provider|


### PR DESCRIPTION
This PR has several changes, the core of it being moving configuration settings from environment variables to a config file for secrets that are variable in deployment.

There are several other commits which are mostly cosmetic. Please read each commit for details.

https://trello.com/c/nusU3o0e/800-update-govuk-dns-to-get-route-53-and-google-cloud-dns-configuration-from-config-file