### PR TITLE
Bugfixes and remove "dns_name"

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,8 +189,7 @@ origin: example.com.
 
 deployment:
   gcp:
-    zone_name: 'my-google-zone'
-    dns_name: 'google.zone'
+    zone_name: 'example-com'
   aws:
     zone_id: 'SOMEROUTE53ZONEID'
 

--- a/jenkins.sh
+++ b/jenkins.sh
@@ -19,5 +19,6 @@ git clone 'git@github.com:alphagov/govuk-dns-config.git'
 cp govuk-dns-config/$ZONEFILE .
 
 bundle install --path "${HOME}/bundles/${JOB_NAME}"
+bundle exec rake validate_yaml
 bundle exec rake generate_terraform
 bundle exec rake ${CMD}

--- a/lib/tasks/generate_terraform.rake
+++ b/lib/tasks/generate_terraform.rake
@@ -26,7 +26,7 @@ task :generate_terraform do
 
   # Render all the expected files
   providers.each { |current_provider|
-    abort("Must set deployment options in configuration file") if deployment[current_provider].empty?
+    abort('Must set deployment options in configuration file') if deployment[current_provider].empty?
 
     deploy_vars = deployment[current_provider]
 

--- a/lib/tasks/generate_terraform.rake
+++ b/lib/tasks/generate_terraform.rake
@@ -23,9 +23,9 @@ task :generate_terraform do
 
   # Render all the expected files
   providers.each { |current_provider|
-    abort("Must set deployment options in configuration file") if deployment[current_provider.to_sym].empty?
+    abort("Must set deployment options in configuration file") if deployment[current_provider].empty?
 
-    deploy_vars = deployment[current_provider.to_sym]
+    deploy_vars = deployment[current_provider]
 
     out = generate_terraform_object(current_provider, records, deploy_vars)
 

--- a/lib/tasks/generate_terraform.rake
+++ b/lib/tasks/generate_terraform.rake
@@ -18,8 +18,11 @@ task :generate_terraform do
 
   # Load configuration
   config_file = YAML.load_file(zonefile)
-  records = config_file['records']
+  origin = config_file['origin']
   deployment = config_file['deployment']
+  records = config_file['records']
+
+  abort('Origin does not have trailing dot') unless origin =~ /\.$/
 
   # Render all the expected files
   providers.each { |current_provider|
@@ -27,7 +30,7 @@ task :generate_terraform do
 
     deploy_vars = deployment[current_provider]
 
-    out = generate_terraform_object(current_provider, records, deploy_vars)
+    out = generate_terraform_object(current_provider, origin, records, deploy_vars)
 
     provider_dir = "#{TMP_DIR}/#{current_provider}"
     Dir.mkdir(provider_dir) unless File.exist?(provider_dir)

--- a/lib/tasks/terraform.rake
+++ b/lib/tasks/terraform.rake
@@ -87,10 +87,6 @@ def _validate_terraform_environment
 
   providers.each { |current_provider|
     required_vars = REQUIRED_ENV_VARS[current_provider.to_sym]
-    required_vars[:tf].each { |var|
-      ENV["TF_VAR_#{var}"] = required_from_env(var)
-    }
-
     required_vars[:env].each { |var|
       required_from_env(var)
     }

--- a/lib/tasks/utilities/generate.rb
+++ b/lib/tasks/utilities/generate.rb
@@ -1,9 +1,9 @@
 require 'digest'
 
-def generate_terraform_object(provider, records, deployment_config)
+def generate_terraform_object(provider, origin, records, deployment_config)
   case provider
   when 'gcp'
-    resources = { google_dns_record_set: _get_gcp_resource(records, deployment_config) }
+    resources = { google_dns_record_set: _get_gcp_resource(records, origin, deployment_config) }
   when 'aws'
     resources = { aws_route53_record: _get_aws_resource(records, deployment_config) }
   end
@@ -12,7 +12,7 @@ def generate_terraform_object(provider, records, deployment_config)
   }
 end
 
-def _get_gcp_resource(records, deployment_config)
+def _get_gcp_resource(records, origin, deployment_config)
   resource_hash = Hash.new
 
   grouped_records = records.group_by { |rec| [rec['subdomain'], rec['record_type']] }
@@ -22,7 +22,7 @@ def _get_gcp_resource(records, deployment_config)
     data = record_set.collect { |r| r['data'] }.sort
     title = _get_resource_title(subdomain, data, type)
 
-    record_name = subdomain == '@' ? deployment_config['dns_name'] : "#{subdomain}.#{deployment_config['dns_name']}"
+    record_name = subdomain == '@' ? origin : "#{subdomain}.#{origin}"
 
     resource_hash[title] = {
       managed_zone: deployment_config['zone_name'],

--- a/spec/generate_spec.rb
+++ b/spec/generate_spec.rb
@@ -65,9 +65,9 @@ RSpec.describe 'generate' do
 
   describe '_get_gcp_resource' do
     it 'should produce an object which matches the gcp cloudDNS terraform resource' do
+      origin = 'my.dnsname.com.'
       deployment = {
         'zone_name' => 'my-google-zone',
-        'dns_name'  => 'my.dnsname.com'
       }
       records = [
         {
@@ -80,20 +80,20 @@ RSpec.describe 'generate' do
       expect = {
         'test_236b5c05fab203a25167bb2bcac37372' => {
           managed_zone: 'my-google-zone',
-          name: 'test.my.dnsname.com',
+          name: 'test.my.dnsname.com.',
           type: 'NS',
           ttl: '86400',
           rrdatas: ['example.com.'],
         }
       }
 
-      expect(_get_gcp_resource(records, deployment)).to eq(expect)
+      expect(_get_gcp_resource(records, origin, deployment)).to eq(expect)
     end
 
     it 'should not include the "@" in the name field' do
+      origin = 'my.dnsname.com.'
       deployment = {
         'zone_name' => 'my-google-zone',
-        'dns_name'  => 'my.dnsname.com'
       }
       records = [
         {
@@ -104,15 +104,15 @@ RSpec.describe 'generate' do
         }
       ]
 
-      result = _get_gcp_resource(records, deployment)
-      expect(result['AT_4be974591aeffe148587193aac4d4b63'][:name]).to eq('my.dnsname.com')
+      result = _get_gcp_resource(records, origin, deployment)
+      expect(result['AT_4be974591aeffe148587193aac4d4b63'][:name]).to eq('my.dnsname.com.')
     end
 
 
     it 'should group records by subdomain and type' do
+      origin = 'my.dnsname.com.'
       deployment = {
         'zone_name' => 'my-google-zone',
-        'dns_name'  => 'my.dnsname.com'
       }
       records = [
         {
@@ -131,14 +131,14 @@ RSpec.describe 'generate' do
       expect = {
         'test_51713ce0554bf6c6b40b5d47015cfce3' => {
           managed_zone: 'my-google-zone',
-          name: 'test.my.dnsname.com',
+          name: 'test.my.dnsname.com.',
           type: 'NS',
           ttl: '86400',
           rrdatas: ['example.com.', 'example2.com.'],
         }
       }
 
-      expect(_get_gcp_resource(records, deployment)).to eq(expect)
+      expect(_get_gcp_resource(records, origin, deployment)).to eq(expect)
     end
   end
 
@@ -240,10 +240,10 @@ RSpec.describe 'generate' do
         }.freeze,
       ].freeze
 
+      origin = 'my.dnsname.com.'
       deployment = {
         'gcp' => {
-          'zone_name' => 'my-google-zone',
-          'dns_name'  => 'my.dnsname.com'
+          'dns_name'  => 'my.dnsname.com.'
         },
         'aws' => {
           'zone_id' => 'route53zoneid'
@@ -259,7 +259,7 @@ RSpec.describe 'generate' do
         result = nil
         # Because the records are frozen this (should) error if they're modified
         expect {
-          result = generate_terraform_object(current_provider, records, deployment)
+          result = generate_terraform_object(current_provider, origin, records, deployment)
         }.to_not raise_error
 
         expect(result).to include(:resource)


### PR DESCRIPTION
Please see commits for detail.

The main change is a difference in setting the config. Previously we set the "dns_name" which is always the same origin, so remove the repetition. 

It also adds a check that the origin has a trailing dot, otherwise Google _will_ fail.