### PR TITLE
Truncate zone on import

### DIFF
--- a/lib/tasks/import_bind.rake
+++ b/lib/tasks/import_bind.rake
@@ -35,6 +35,10 @@ task :import_bind do
       subdomain = record.label
     end
 
+    if record.label =~ /#{zone.origin}/
+      subdomain = record.label.gsub(zone.origin, '').gsub(/\.$/, '')
+    end
+
     # Records inherit fields for a parent Record object, we explicitly read
     # the fields as we cannot extract them with the instance_variables method
     record_hash = {


### PR DESCRIPTION
If the subdomain contains the full origin within the data, remove the origin name from the data, along with the trailing dot, otherwise the subdomain data will end up being something like:

`www.example.com.example.com`

This format sometimes occurs in zone files when they are imported.