### PR TITLE
Update checks for blank subdomains

### DIFF
--- a/lib/tasks/import_bind.rake
+++ b/lib/tasks/import_bind.rake
@@ -35,8 +35,8 @@ task :import_bind do
       subdomain = record.label
     end
 
-    if record.label =~ /#{zone.origin}/
-      subdomain = record.label.gsub(zone.origin, '').gsub(/\.$/, '')
+    if record.label =~ /^.*\.#{zone.origin}/
+      subdomain = record.label.scan(/^(.*)\.#{zone.origin}/).flatten.first
     end
 
     # Records inherit fields for a parent Record object, we explicitly read

--- a/lib/tasks/utilities/zone_file_field_validator.rb
+++ b/lib/tasks/utilities/zone_file_field_validator.rb
@@ -53,6 +53,7 @@ module ZoneFileFieldValidator
   end
 
   def self.subdomain?(subdomain)
+    return false if subdomain == '' # Should not be blank, should be '@'
     return true if subdomain == '@' # Reference to $ORIGIN
     # Allowed characters are numbers, lower-case letters, periods and hyphens per part
     # Wildcard character (*) is only allowed on its own in the least significant part
@@ -61,6 +62,7 @@ module ZoneFileFieldValidator
   end
 
   def self.txt_subdomain?(subdomain)
+    return false if subdomain == '' # Should not be blank, should be '@'
     return true if subdomain == '@' # Reference to $ORIGIN
     # TXT subdomains may contain underscores and upper case letters in
     # addition to other subdomain characters

--- a/spec/validate_yaml_spec.rb
+++ b/spec/validate_yaml_spec.rb
@@ -89,6 +89,10 @@ RSpec.describe 'Zone file field validators' do
   end
 
   describe 'subdomain?' do
+    it 'should be false for blank rather than "@"' do
+      expect(ZoneFileFieldValidator.subdomain?('')).to be false
+    end
+
     it 'should be true for "@" (reference to $ORIGIN' do
       expect(ZoneFileFieldValidator.subdomain?('@')).to be true
     end
@@ -130,6 +134,10 @@ RSpec.describe 'Zone file field validators' do
   end
 
   describe 'txt_subdomain?' do
+    it 'should be false for blank rather than "@"' do
+      expect(ZoneFileFieldValidator.txt_subdomain?('')).to be false
+    end
+
     it 'should be true for "@" (reference to $ORIGIN' do
       expect(ZoneFileFieldValidator.txt_subdomain?('@')).to be true
     end


### PR DESCRIPTION
If a subdomain entry is blank, it should be set as "@". This updates the import and the spec tests to catch this condition.