### PR TITLE
Fail tests with informative error message

### DIFF
--- a/spec/validate_published_dns_spec.rb
+++ b/spec/validate_published_dns_spec.rb
@@ -50,7 +50,7 @@ RSpec.describe 'Validate the published DNS against the YAML.', validate_dns: tru
       rescue Dnsruby::NXDomain
         # NXDomain is a test failure let RSpec know.
         it 'should exist.' do
-          expect(true).to be false, "NXDomain response, expected '#{subdomain}' to exist."
+          fail "NXDomain response, expected '#{subdomain}' to exist."
         end
         next
       rescue Dnsruby::ResolvTimeout
@@ -60,7 +60,7 @@ RSpec.describe 'Validate the published DNS against the YAML.', validate_dns: tru
         next
       rescue Dnsruby::ServFail
         it 'should not error.' do
-          expect(true).to be false, "Dnsruby::ServFail response for '#{subdomain}'"
+          fail "Dnsruby::ServFail response for '#{subdomain}'"
         end
         next
       end

--- a/spec/validate_published_dns_spec.rb
+++ b/spec/validate_published_dns_spec.rb
@@ -58,6 +58,11 @@ RSpec.describe 'Validate the published DNS against the YAML.', validate_dns: tru
         # or similar for total validation.
         puts "Timeout getting response for '#{subdomain}'."
         next
+      rescue Dnsruby::ServFail
+        it 'should not error.' do
+          expect(true).to be false, "Dnsruby::ServFail response for '#{subdomain}'"
+        end
+        next
       end
 
       # The YAML does not include SOA records so remove those.


### PR DESCRIPTION
Currently the tests are failing on the `training` subdomain, but this isn't clear from the test results since it just errors with a cryptic:

```
Failure/Error: records = resolver.query(query, 'ANY')
Dnsruby::ServFail
```

https://deploy.publishing.service.gov.uk/job/Validate_published_DNS/321/console

With this change, we'll get a informative error message and we'll be able to fix the cause.

```
  1) Validate the published DNS against the YAML. The 'training' subdomain should not error.
```

https://deploy.publishing.service.gov.uk/job/Validate_published_DNS/326/console