### PR TITLE
Remove "all" option

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Terraform resources can then be created in `tf-tmp` for your providers using:
 $ ZONEFILE=zonefile.yaml PROVIDERS=<dns provider> bundle exec rake generate_terraform
 ```
 
-Where `<dns provider>` is one of 'gcp', 'aws' or 'all'.
+Where `<dns provider>` is either 'gcp' or 'aws'.
 
 This terraform can then be planned and applied using:
 ```bash
@@ -86,7 +86,7 @@ $ bundle exec rake <task>
 
 with required environment variables either being set by `export` or before the command e.g.:
 ```bash
-$ PROVIDERS=all ZONEFILE=zonefile.yaml bundle exec rake generate_terraform
+$ PROVIDERS=aws ZONEFILE=zonefile.yaml bundle exec rake generate_terraform
 ```
 
 ### Management ###
@@ -115,14 +115,13 @@ $ ZONEFILE=zone.bind OUTPUTFILE=out.yaml bundle exec rake import_bind
 
 ## Generate Terraform ##
 
-Given a YAML zonefile produce Terraform JSON for each specified provider. The produced Terraform is put in a directory called `tf-tmp/<provider>` 
+Given a YAML zonefile produce Terraform JSON for each specified provider. The produced Terraform is put in a directory called `tf-tmp/<provider>`
 
 * `ZONEFILE` (required) - The YAML formatted file to use
 * `PROVIDERS` (required) - Which DNS providers to produce Terraform for
 
 ### Providers ###
 
-* `all` - Special value, uses all available providers.
 * `gcp` - [Google Cloud DNS](https://cloud.google.com/dns/docs/)
 * `aws` - [AWS Route 53](https://aws.amazon.com/aws)
 

--- a/lib/tasks/terraform.rake
+++ b/lib/tasks/terraform.rake
@@ -34,7 +34,7 @@ def _run_terraform_cmd_for_providers(command)
 
   puts command
 
-  providers.each { |current_provider|
+  providers.each do |current_provider|
     puts "Running for #{current_provider}"
 
     puts "Using statefile: s3://#{bucket_name}/#{current_provider}/#{statefile_name}"
@@ -57,7 +57,7 @@ def _run_terraform_cmd_for_providers(command)
     terraform_cmd << "#{TMP_DIR}/#{current_provider}"
 
     _run_system_command(terraform_cmd.join(' '))
-  }
+  end
 end
 
 def _local_state_check

--- a/lib/tasks/utilities/common.rb
+++ b/lib/tasks/utilities/common.rb
@@ -47,13 +47,9 @@ def bucket_name
 end
 
 def providers
-  if ENV['PROVIDERS'] == 'all'
-    return ALLOWED_PROVIDERS
-  end
-
   if not ENV['PROVIDERS'].nil?
     return [ENV['PROVIDERS']]
   end
 
-  abort("Please set the 'PROVIDERS' environment variable to one of: #{ALLOWED_PROVIDERS.join(', ')} or all")
+  abort("Please set the 'PROVIDERS' environment variable to one of: #{ALLOWED_PROVIDERS.join(', ')}")
 end


### PR DESCRIPTION
We do not think we should be running everything at once as it introduces
uncertainty. Remove the "all" option for the time-being, although the code
to run multiple providers still exists.