### PR TITLE
Split data entries at 255 characters.

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,9 +1,9 @@
 #!/usr/bin/env groovy
 
+library("govuk")
 REPOSITORY = 'govuk-dns'
 
 node ("terraform-0.8.1") {
-  def govuk = load '/var/lib/jenkins/groovy_scripts/govuk_jenkinslib.groovy'
 
   try {
     stage ("Checkout") {

--- a/lib/tasks/utilities/generate.rb
+++ b/lib/tasks/utilities/generate.rb
@@ -19,7 +19,7 @@ def _get_gcp_resource(records, origin, deployment_config)
 
   grouped_records.each { |subdomain_and_type, record_set|
     subdomain, type = subdomain_and_type
-    data = record_set.collect { |r| r['data'] }.sort
+    data = record_set.collect { |r| _split_line(r['data']) }.flatten
     title = _get_resource_title(subdomain, data, type)
 
     record_name = subdomain == '@' ? origin : "#{subdomain}.#{origin}"
@@ -43,7 +43,7 @@ def _get_aws_resource(records, deployment_config)
 
   grouped_records.each { |subdomain_and_type, record_set|
     subdomain, type = subdomain_and_type
-    data = record_set.collect { |r| r['data'] }.sort
+    data = record_set.collect { |r| _split_line(r['data']) }.flatten
     title = _get_resource_title(subdomain, data, type)
 
     record_name = subdomain == '@' ? "" : subdomain.to_s
@@ -58,6 +58,10 @@ def _get_aws_resource(records, deployment_config)
   }
 
   resource_hash
+end
+
+def _split_line(data)
+  data.chars.each_slice(255).to_a.map &:join
 end
 
 def _get_tf_safe_data(data)

--- a/spec/generate_spec.rb
+++ b/spec/generate_spec.rb
@@ -90,6 +90,25 @@ RSpec.describe 'generate' do
       expect(_get_gcp_resource(records, origin, deployment)).to eq(expect)
     end
 
+    it 'should split long data lines to a maximum of 255 characters' do
+      origin = 'my.dnsname.com.'
+      deployment = {
+        'zone_name' => 'my-google-zone',
+      }
+      data = '123456790' * 30
+      records = [
+        {
+          'record_type' => 'TXT',
+          'subdomain' => 'test',
+          'ttl' => '86400',
+          'data' => data,
+        }
+      ]
+      rrdatas = ["123456790123456790123456790123456790123456790123456790123456790123456790123456790123456790123456790123456790123456790123456790123456790123456790123456790123456790123456790123456790123456790123456790123456790123456790123456790123456790123456790123456790123", "456790123456790"]
+      result = _get_gcp_resource(records, origin, deployment)
+      expect(result['test_d115507cc3a4339868fe9a6315c2a82d'][:rrdatas]).to eq(rrdatas)
+    end
+
     it 'should not include the "@" in the name field' do
       origin = 'my.dnsname.com.'
       deployment = {
@@ -164,6 +183,23 @@ RSpec.describe 'generate' do
       }
 
       expect(_get_aws_resource(records, deployment)).to eq(expect)
+    end
+
+    it 'should split long data lines to a maximum of 255 characters' do
+      deployment = { 'zone_id' => 'route53zoneid' }
+      data = '123456790' * 30
+      records = [
+        {
+          'record_type' => 'TXT',
+          'subdomain' => 'test',
+          'ttl' => '86400',
+          'data' => data,
+        }
+      ]
+      expected = ["123456790123456790123456790123456790123456790123456790123456790123456790123456790123456790123456790123456790123456790123456790123456790123456790123456790123456790123456790123456790123456790123456790123456790123456790123456790123456790123456790123456790123", "456790123456790"]
+      result = _get_aws_resource(records, deployment)
+      puts(result.keys)
+      expect(result['test_d115507cc3a4339868fe9a6315c2a82d'][:records]).to eq(expected)
     end
 
     it 'should not include the "@" in the name field' do


### PR DESCRIPTION
TXT and SPF records have a maximum string length, but applications are
supposed to automatically concatenate adjacent strings. This change
automatically splits strings at 255 chars so that the terraform will
send a list of records. It removes the sort so that strings remain in
the correct order for concatenation.