### PR TITLE
Remove validator test for whitespace in TXT records

### DIFF
--- a/lib/tasks/utilities/zone_file_field_validator.rb
+++ b/lib/tasks/utilities/zone_file_field_validator.rb
@@ -70,17 +70,6 @@ module ZoneFileFieldValidator
     !!(regex =~ subdomain)
   end
 
-  def self.txt_data_whitespace?(data)
-    whitespace = data.scan(/\s/).length
-    esc_whitespace = data.scan(/(\\\s)/).length
-
-    if whitespace.positive?
-      if esc_whitespace < whitespace
-        return false
-      end
-    end
-  end
-
   def self.txt_data_semicolons?(data)
     semicolons = data.scan(/;/).length
     esc_semicolons = data.scan(/(\\;)/).length
@@ -131,7 +120,6 @@ module ZoneFileFieldValidator
       errors << "MX record data field must be of the form '<priority> <lower-case FQDN>', got: '#{data}'." if ! mx?(data)
     when 'TXT'
       errors << "TXT record data field must not be empty." if data.empty?
-      errors << "TXT record data whitespace should be escaped, got: '#{data}'." if ! txt_data_whitespace?(data).nil?
       errors << "TXT record data semicolons should be escaped, got: '#{data}'." if ! txt_data_semicolons?(data).nil?
     when 'CNAME'
       errors << "CNAME record data field must be a lower-case FQDN, got: '#{data}'." if ! fqdn?(data)

--- a/spec/validate_yaml_spec.rb
+++ b/spec/validate_yaml_spec.rb
@@ -157,24 +157,6 @@ RSpec.describe 'Zone file field validators' do
     end
   end
 
-  describe 'txt_data_whitespace?' do
-    it 'should be nil when there is no whitespace' do
-      expect(ZoneFileFieldValidator.txt_data_whitespace?('foobar')).to be_nil
-    end
-
-    it 'should be nil when there is escaped whitespace' do
-      expect(ZoneFileFieldValidator.txt_data_whitespace?('foo\ bar')).to be_nil
-    end
-
-    it 'should be false when there is non-escaped whitespace' do
-      expect(ZoneFileFieldValidator.txt_data_whitespace?('foo bar')).to be false
-    end
-
-    it 'should be false when there is both non-escaped whitespace and escaped whitespace' do
-      expect(ZoneFileFieldValidator.txt_data_whitespace?('foo\ bar bar')).to be false
-    end
-  end
-
   describe 'txt_data_semicolons?' do
     it 'should be nil when there are no semicolons' do
       expect(ZoneFileFieldValidator.txt_data_semicolons?('foobar')).to be_nil
@@ -264,18 +246,6 @@ RSpec.describe 'Zone file field validators' do
       }
 
       expect(ZoneFileFieldValidator.get_record_errors(record)).to be_empty
-    end
-
-    it 'should raise errors for non-escaped whitespace in a TXT data field' do
-      record = {
-        'ttl' => '3600',
-        'record_type' => 'TXT',
-        'subdomain' => '_extra_test',
-        'data' => '"arbitrary\ data\; and such"',
-      }
-
-      result = ZoneFileFieldValidator.get_record_errors(record)
-      expect(result.length).to be 1
     end
 
     it 'should raise errors for a non-escaped semicolon in a TXT data field' do


### PR DESCRIPTION
In govuk-dns-config/412080c3 a validator test was added to reject TXT record
data containing unescaped whitespace. However, we now have a legitimate case
where we want to allow unescaped whitespace in TXT records. We want to allow the
GoogleDNS API to split on whitespace into separated quoted strings to cope with
cases where the data string is > 255 characters, e.g. DKIM or DMARC records.

For other cases people will need to escape whitespace to avoid their TXT records
being split on whitespace if this is not what they want.

Co-authored-by: James Alderman <james.alderman@digital.cabinet-office.gov.uk>