### PR TITLE
Add DMARC TXT record split

### DIFF
--- a/lib/tasks/utilities/generate.rb
+++ b/lib/tasks/utilities/generate.rb
@@ -61,11 +61,21 @@ def _get_aws_resource(records, deployment_config)
 end
 
 def _split_line_gcp(data)
-  data.scan(/.{1,255}/).join(' ')
+  if data.include? "v=DMARC1"
+    data1 = data.delete(' ')
+    data1.split(';').join('; ')
+  elsif data.include? "v=DKIM1"
+    data.scan(/.{1,255}/).join(' ')
+  end
 end
 
 def _split_line_aws(data)
-  data.scan(/.{1,255}/).join('""')
+  if data.include? "v=DMARC1"
+    data1 = data.delete(' ')
+    data1.split(';').join(';""')
+  elsif data.include? "v=DKIM1"
+    data.scan(/.{1,255}/).join('""')
+  end
 end
 
 def _get_tf_safe_data(data)


### PR DESCRIPTION
We were splitting long txt records at 255 chars to fit max record size limit.
This doesn't look pretty for DMARC records and may or may not actually work.
This change handles DMARC and DKIM records differently splitting DKIM records at 255
chars and DMARC records at natural boundaries (;)