### PR TITLE
Split DMARC TXT records on commas

### DIFF
--- a/lib/tasks/utilities/generate.rb
+++ b/lib/tasks/utilities/generate.rb
@@ -63,7 +63,7 @@ end
 def _split_line_gcp(data)
   if data.include? "v=DMARC1" and data.length > 254
     data1 = data.delete(' ')
-    data1.split(';').join('; ')
+    data1.split(';').join('; ').split(',').join(', ')
   else 
     data.scan(/.{1,255}/).join(' ')
   end
@@ -72,7 +72,7 @@ end
 def _split_line_aws(data)
   if data.include? "v=DMARC1" and data.length > 254
     data1 = data.delete(' ')
-    data1.split(';').join(';""')
+    data1.split(';').join(';""').split(',').join(',""')
   else 
     data.scan(/.{1,255}/).join('""')
   end


### PR DESCRIPTION
In ea2b783 code was added to split DMARC TXT records longer than 255 characters
on semi-colons. However, the ruf and rua segments can be long and could also
exceed the 255 character limit so we need to split on commas too.