### PR TITLE
Lower minimum TTL limit in validator

### DIFF
--- a/lib/tasks/utilities/zone_file_field_validator.rb
+++ b/lib/tasks/utilities/zone_file_field_validator.rb
@@ -1,5 +1,5 @@
 module ZoneFileFieldValidator
-  MIN_TTL = 300
+  MIN_TTL = 60
   MAX_TTL = 86400 # 1 day
 
   def self.fqdn?(domainname)


### PR DESCRIPTION
The current limit is not low enough for some of the values we need.
It seems an arbitary limit as both GCP and AWS allow much lower limits.
Reducing the limit to the mimimum value we currently need.