### PR TITLE
Improve splitting of DMARC TXT records for Route53

### DIFF
--- a/lib/tasks/utilities/generate.rb
+++ b/lib/tasks/utilities/generate.rb
@@ -71,9 +71,12 @@ end
 
 def _split_line_aws(data)
   if data.include? "v=DMARC1" and data.length > 254
-    data1 = data.delete(' ')
-    data1.split(';').join(';""').split(',').join(',""')
-  else 
+    data
+      .delete(' ')
+      .split(/(?<=[;,])/)
+      .map{ |e| '"'+e+'"' }
+      .join
+  else
     data.scan(/.{1,255}/).join('""')
   end
 end


### PR DESCRIPTION
The _split_line_aws() function splits DMARC TXT records longer than 255
characters into separate quoted strings. Although this is creating the TXT
records correctly in Route53 the terraform resources are not idempotent and
attempt to update the records on every terraform plan/apply. This is because the
function was not correctly adding double quotes at the start of the first token
and at the end of the last token, so wasn't matchng what was coming back on the
resource refresh.

I'm fixing this here by using map to correctly quote each element in the split.
The scary looking split regex is just a positive lookbehind that captures the
substring and the delimiter in the capture group.