### PR TITLE
Revert "Improve splitting of DMARC TXT records for Route53"

### DIFF
--- a/lib/tasks/utilities/generate.rb
+++ b/lib/tasks/utilities/generate.rb
@@ -70,13 +70,10 @@ def _split_line_gcp(data)
 end
 
 def _split_line_aws(data)
-  if data.include?("v=DMARC1") && (data.length > 254)
-    data
-      .delete(' ')
-      .split(/(?<=[;,])/)
-      .map { |e| '"' + e + '"' }
-      .join
-  else
+  if data.include? "v=DMARC1" and data.length > 254
+    data1 = data.delete(' ')
+    data1.split(';').join(';""').split(',').join(',""')
+  else 
     data.scan(/.{1,255}/).join('""')
   end
 end

--- a/lib/tasks/utilities/generate.rb
+++ b/lib/tasks/utilities/generate.rb
@@ -70,10 +70,10 @@ def _split_line_gcp(data)
 end
 
 def _split_line_aws(data)
-  if data.include? "v=DMARC1" and data.length > 254
+  if data.include?("v=DMARC1") && (data.length > 254)
     data1 = data.delete(' ')
     data1.split(';').join(';""').split(',').join(',""')
-  else 
+  else
     data.scan(/.{1,255}/).join('""')
   end
 end


### PR DESCRIPTION
This reverts commit 24bd36956af839510182842e500f6a4c7d436dff. Reverting because
it is erroring when adding DMARC TXT records to route53.