### PR TITLE
Allow underscores in FQDNs

### DIFF
--- a/lib/tasks/utilities/zone_file_field_validator.rb
+++ b/lib/tasks/utilities/zone_file_field_validator.rb
@@ -5,9 +5,9 @@ module ZoneFileFieldValidator
   def self.fqdn?(domainname)
     regex = %r{
       \A               # Match the start of the string
-      [-a-z0-9]+       # Match the first label made of numbers, letters and hyphens
+      [-a-z0-9_]+      # Match the first label made of numbers, letters and hyphens
       \.               # Make sure we have at least a TLD
-      [-.a-z0-9]*      # Other characters should alphanumeric, periods or hyphens
+      [-.a-z0-9_]*     # Other characters should alphanumeric, periods or hyphens
       \.               # Final character should be a period
       \z               # Match the end of the string
     }x

--- a/spec/validate_yaml_spec.rb
+++ b/spec/validate_yaml_spec.rb
@@ -6,6 +6,10 @@ RSpec.describe 'Zone file field validators' do
       expect(ZoneFileFieldValidator.fqdn?('example.com.')).to be true
     end
 
+    it 'should be true for examples containing underscores' do
+      expect(ZoneFileFieldValidator.fqdn?('_example.com.')).to be true
+    end
+
     it 'should be true for long examples' do
       expect(ZoneFileFieldValidator.fqdn?('this.is-a.surprisingly.long.example.1.com.')).to be true
     end
@@ -18,12 +22,12 @@ RSpec.describe 'Zone file field validators' do
       expect(ZoneFileFieldValidator.fqdn?('.com.')).to be false
     end
 
-    it 'should be false for examples containing underscores' do
-      expect(ZoneFileFieldValidator.fqdn?('bad_example.com.')).to be false
+    it 'should be false for examples containing semicolons' do
+      expect(ZoneFileFieldValidator.fqdn?('bad;example.com.')).to be false
     end
 
     it 'should be false for examples lacking a trailing period' do
-      expect(ZoneFileFieldValidator.fqdn?('bad_example.com')).to be false
+      expect(ZoneFileFieldValidator.fqdn?('bad;example.com')).to be false
     end
 
     it 'should be false for examples containing unicode' do
@@ -83,8 +87,8 @@ RSpec.describe 'Zone file field validators' do
     it 'should be false for strings with an invalid fqdn' do
       expect(ZoneFileFieldValidator.mx?('10 .com.')).to be false
       expect(ZoneFileFieldValidator.mx?('10 0.0.0.0')).to be false
-      expect(ZoneFileFieldValidator.mx?('10 foo_bar.com')).to be false
-      expect(ZoneFileFieldValidator.mx?('10 foo_bar.com.')).to be false
+      expect(ZoneFileFieldValidator.mx?('10 foo;bar.com')).to be false
+      expect(ZoneFileFieldValidator.mx?('10 foo;bar.com.')).to be false
     end
   end
 


### PR DESCRIPTION
- Amazon Certificate Manager, for example, provides URLs for verification that contain underscores, so we need to support them.