### PR TITLE
Add support for IPv6 addresses to the validator

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,6 +215,7 @@ correct upstream hosted zone.
 `record_type` should be one of:
 
 * A
+* AAAA
 * NS
 * MX
 * TXT
@@ -223,16 +224,19 @@ correct upstream hosted zone.
 We only validate a subset of [RFC 1035](https://www.ietf.org/rfc/rfc1035.txt). If you do not see the record you wish to add in the following list it will not be considered valid and will need to be added.
 
 ### Data fields ###
+
 This is a list of currently supported record types and the expected format of their data fields.
 
 * **A**: of the form `a.a.a.a` where `a` is a number between 0 and 255 and may be zero padded. For example both `127.0.0.1` and `127.000.000.001` are both valid.
+* **AAAA**: of the form `a:a:a:a:a:a:a:a` where `a` is a 16-bit hex value (between `0000` and `ffff`). Leading zeroes may be omitted, and a single run of zero field values can be compressed to `::`. For example, `ff06:00c4:0000:0000:0000:0000:0000:00c3`, `ff06:c4:0:0:0:0:0:c3`, and `ff06:c4::c3` are all valid representations of the same address.
 * **NS**: a fully qualified domain name (FQDN) containing only numbers, lower-case ASCII letters, hyphens and periods. The trailing period must be present, for example `example.com.` is valid while `example.com` is not.
 * **MX**: a priority value followed by a FQDN (see NS record for details). For example `10 example.com.`
 * **TXT**: any non-empty string. TXT fields should have all whitespace escaped (`\ `). If whitespace is intended to indicate multiple records then these should be added separately.
 * **CNAME**: a FQDN (see NS record).
 
 ### Subdomain ###
-For A, NS, MX, CNAME records it may either be:
+
+For A, AAAA, NS, MX, CNAME records it may either be:
 
 * `@` to refer to the domain origin
 * *or* a label formed of numbers, letters, hyphens and periods. For example `test-api` is valid, `test_api` is not.
@@ -240,6 +244,7 @@ For A, NS, MX, CNAME records it may either be:
 TXT records follow the same rules but their labels may also contain underscores. For example both `@` and `_api_key` are valid TXT subdomains.
 
 ### TTL ###
+
 Must be an integer value between 300s and 86400s (1 day).
 
 ## Rationale ##

--- a/lib/tasks/utilities/zone_file_field_validator.rb
+++ b/lib/tasks/utilities/zone_file_field_validator.rb
@@ -37,6 +37,27 @@ module ZoneFileFieldValidator
     !!(regex =~ address)
   end
 
+  def self.ipv6?(address)
+    regex = %r{
+      \A
+      (
+        (
+          (?=.*(::))
+          (?!.*\3.+\3)
+        )\3?|
+        [\dA-F]{1,4}:
+      )
+      ([\dA-F]{1,4}(\3|:\b)|\2){5}
+      (
+        ([\dA-F]{1,4}(\3|:\b|$)|\2){2}|
+        (((2[0-4]|1\d|[1-9])?\d|25[0-5])\.?\b){4}
+      )
+      \z
+    }xi
+
+    !!(regex =~ address)
+  end
+
   def self.mx?(priority_and_domain)
     regex = %r{
       \A               # Start of string
@@ -114,6 +135,8 @@ module ZoneFileFieldValidator
       errors << "Missing 'record_type' field in record #{record}."
     when 'A'
       errors << "A record data field must be an IPv4 address, got: '#{data}'." if ! ipv4?(data)
+    when 'AAAA'
+      errors << "AAAA record data field must be an IPv6 address, got: '#{data}'." if ! ipv6?(data)
     when 'NS'
       errors << "NS record data field must be a lower-case FQDN (with a trailing dot), got: '#{data}'." if ! fqdn?(data)
     when 'MX'

--- a/spec/validate_yaml_spec.rb
+++ b/spec/validate_yaml_spec.rb
@@ -69,6 +69,40 @@ RSpec.describe 'Zone file field validators' do
     end
   end
 
+  describe 'ipv6?' do
+    it 'should be true for trivial examples' do
+      expect(ZoneFileFieldValidator.ipv6?('1111:2222:3333:4444:5555:6666:7777:8888')).to be true
+    end
+
+    it 'should be true for the "minimum" value' do
+      expect(ZoneFileFieldValidator.ipv6?('::1')).to be true
+    end
+
+    it 'should be true for values with leading zeroes' do
+      expect(ZoneFileFieldValidator.ipv6?('ff06:00c4:0000:0000:0000:0000:0000:00c3')).to be true
+    end
+
+    it 'should be true for values without leading zeroes' do
+      expect(ZoneFileFieldValidator.ipv6?('ff06:c4:0:0:0:0:0:c3')).to be true
+    end
+
+    it 'should be true for values with compressed runs of zero fields' do
+      expect(ZoneFileFieldValidator.ipv6?('ff06:c4::c3')).to be true
+    end
+
+    it 'should be false for values with fewer than 8 blocks' do
+      expect(ZoneFileFieldValidator.ipv6?('0:0:0:0:0:0:0')).to be false
+    end
+
+    it 'should be false for values with more than 4 blocks' do
+      expect(ZoneFileFieldValidator.ipv6?('0:0:0:0:0:0:0:0:0')).to be false
+    end
+
+    it 'should be false for values that contain invalid hex characters' do
+      expect(ZoneFileFieldValidator.ipv6?('a:b:c:d:e:f:g:h')).to be false
+    end
+  end
+
   describe 'mx?' do
     it 'should be true for trivial examples' do
       expect(ZoneFileFieldValidator.mx?('10 example.com.')).to be true
@@ -207,6 +241,11 @@ RSpec.describe 'Zone file field validators' do
           'record_type' => 'A',
           'subdomain' => 'subdomain',
           'data' => '127.0.0.1',
+        }, {
+          'ttl' => '3600',
+          'record_type' => 'AAAA',
+          'subdomain' => 'subdomain',
+          'data' => '::1',
         }, {
           'ttl' => '3600',
           'record_type' => 'NS',


### PR DESCRIPTION
We need to add IPv6 addresses to the gov.uk apex domain. This is managed by Jisc, so this change isn't directly related, but it's reasonable to think that in the near-ish future we'll start needing to add `AAAA` records to things.