### PR TITLE
ZoneFileFieldValidator: Improve validation error messages

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,7 @@
 on: [push, pull_request]
 
 jobs:
-  tests:
+  test:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/lib/tasks/utilities/zone_file_field_validator.rb
+++ b/lib/tasks/utilities/zone_file_field_validator.rb
@@ -164,9 +164,9 @@ module ZoneFileFieldValidator
     if subdomain.nil?
       errors << "Missing 'subdomain' field in record #{record}."
     elsif type == "TXT" && !txt_subdomain?(subdomain)
-      errors << "Invalid TXT subdomain field, must either be '@' or consist of numbers, letters, hyphens, periods and underscores; got: '#{subdomain}'."
+      errors << "Invalid TXT subdomain field, must either be '@' or consist of numbers, lowercase letters, hyphens, periods and underscores; got: '#{subdomain}'."
     elsif type != "TXT" && !subdomain?(subdomain)
-      errors << "Invalid #{type} subdomain field, must either be '@' or consist of numbers, letters, hyphens, periods, and wildcards; got: '#{subdomain}'."
+      errors << "Invalid #{type} subdomain field, must either be '@' or consist of numbers, lowercase letters, hyphens, periods, and wildcards; got: '#{subdomain}'."
     end
 
     errors

--- a/lib/tasks/utilities/zone_file_field_validator.rb
+++ b/lib/tasks/utilities/zone_file_field_validator.rb
@@ -5,9 +5,9 @@ module ZoneFileFieldValidator
   def self.fqdn?(domainname)
     regex = %r{
       \A               # Match the start of the string
-      [-a-z0-9_]+      # Match the first label made of numbers, letters and hyphens
+      [-a-z0-9_]+      # Match the first label made of numbers, letters, hyphens and underscores
       \.               # Make sure we have at least a TLD
-      [-.a-z0-9_]*     # Other characters should alphanumeric, periods or hyphens
+      [-.a-z0-9_]*     # Other characters should alphanumeric, periods, hyphens and underscores
       \.               # Final character should be a period
       \z               # Match the end of the string
     }x
@@ -81,8 +81,9 @@ module ZoneFileFieldValidator
     return false if subdomain == "" # Should not be blank, should be '@'
     return true if subdomain == "@" # Reference to $ORIGIN
 
-    # Allowed characters are numbers, lower-case letters, periods and hyphens per part
-    # Wildcard character (*) is only allowed on its own in the least significant part
+    # Allowed characters are numbers, lower-case letters, periods,
+    # hyphens and underscores per part. Wildcard character (*) is only
+    # allowed on its own in the least significant part
     regex = /\A(\*\.)?[-_.a-z0-9]*\z|\A\*\z/
 
     subdomain&.match?(regex)

--- a/lib/tasks/utilities/zone_file_field_validator.rb
+++ b/lib/tasks/utilities/zone_file_field_validator.rb
@@ -7,7 +7,7 @@ module ZoneFileFieldValidator
       \A               # Match the start of the string
       [-a-z0-9_]+      # Match the first label made of numbers, letters, hyphens and underscores
       \.               # Make sure we have at least a TLD
-      [-.a-z0-9_]*     # Other characters should alphanumeric, periods, hyphens and underscores
+      [-.a-z0-9_]*     # Other characters should be alphanumeric, periods, hyphens and underscores
       \.               # Final character should be a period
       \z               # Match the end of the string
     }x


### PR DESCRIPTION
- In PRs like https://github.com/alphagov/govuk-dns-config/pull/545, looking at source code and having to parse regexes is not our top priority. So this makes the messaging better so it's more obvious that underscores are OK but that everything should be lowercase.

My Kingdom for OctoDNS...