### PR TITLE
lower minimum TTL for yaml validator

### DIFF
--- a/lib/tasks/utilities/zone_file_field_validator.rb
+++ b/lib/tasks/utilities/zone_file_field_validator.rb
@@ -1,5 +1,5 @@
 module ZoneFileFieldValidator
-  MIN_TTL = 300
+  MIN_TTL = 60
   MAX_TTL = 86400 # 1 day
 
   def self.fqdn?(domainname)


### PR DESCRIPTION
This is to try to achieve a quicker migration of signon.