### PR TITLE
Upgrade GCP terraform provider to 2.20.3

### DIFF
--- a/lib/tasks/utilities/generate.rb
+++ b/lib/tasks/utilities/generate.rb
@@ -34,7 +34,7 @@ end
 def provider_version(tf_provider)
   case tf_provider
   when "google"
-    "1.15.0"
+    "2.20.3"
   when "aws"
     "1.26.0"
   end


### PR DESCRIPTION
This is the latest 2.X version. The 3.X versions are not compatible with
terraform 0.11.

The 1.X to 2.X upgrade doesn't include any breaking changes to the DNS
resources which we use:

https://registry.terraform.io/providers/hashicorp/google/latest/docs/guides/version_2_upgrade

This upgrade should (in theory) allow us to use
`GOOGLE_OAUTH_ACCESS_TOKEN` to authenticate to Google, instead of giving
Jenkins long lived credentials. We'll need to update the Jenkins job to
allow that.

https://trello.com/c/LasnNuz4/561-rationalise-use-of-gcp-credentials-eg-for-dns-deployments