### PR TITLE
Switch to GOOGLE_OAUTH_ACCESS_TOKEN

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ Along with the environment variables set above, when deploying to Google the fol
 
 * `GOOGLE_PROJECT` - project ID
 * `GOOGLE_REGION` - project region
-* `GOOGLE_CREDENTIALS` - JSON credentials for the service account to deploy using (best set using `GOOGLE_CREDENTIALS=$(cat <path to credentials>`).
+* `GOOGLE_OAUTH_ACCESS_TOKEN` - a GCP access token (use `GOOGLE_OAUTH_ACCESS_TOKEN=$(gcloud auth print-access-token)`).
 
 ## Testing ##
 

--- a/lib/tasks/utilities/common.rb
+++ b/lib/tasks/utilities/common.rb
@@ -4,7 +4,7 @@ TMP_DIR = "tf-tmp".freeze
 
 REQUIRED_ENV_VARS = {
   gcp: {
-    env: %w[GOOGLE_CREDENTIALS GOOGLE_REGION GOOGLE_PROJECT].freeze,
+    env: %w[GOOGLE_OAUTH_ACCESS_TOKEN GOOGLE_REGION GOOGLE_PROJECT].freeze,
   }.freeze,
   aws: {
     env: %w[AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY AWS_DEFAULT_REGION].freeze,


### PR DESCRIPTION
Previously the deploy script enforced the presence of
GOOGLE_CREDENTIALS.

Since https://github.com/alphagov/govuk-puppet/pull/11168
GOOGLE_CREDENTIALS are no longer available in Jenkins, instead the code
should expect GOOGLE_OAUTH_ACCESS_TOKEN.

I've also updated the README to mention the correct env var.

https://trello.com/c/LasnNuz4/561-rationalise-use-of-gcp-credentials-eg-for-dns-deployments