### PR TITLE
Fix brew path

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,9 @@ jobs:
       - uses: actions/checkout@v2
       - uses: ruby/setup-ruby@v1
 
+      - name: Set up Homebrew
+        id: set-up-homebrew
+        uses: Homebrew/actions/setup-homebrew@master
       - name: Install Terraform
         run: |
           brew install tfenv


### PR DESCRIPTION
[Homebrew has been removed from $PATH](https://github.com/actions/runner-images/issues/6283) in Ubuntu images on Github actions.

This is the recommended mitigation from the issue, and [uses the action provided by Homebrew](https://github.com/Homebrew/actions/tree/master/setup-homebrew#setup-homebrew-github-action)