### PR TITLE
Update Bundler to 2.4.1

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1361,4 +1361,4 @@ DEPENDENCIES
   rubocop-govuk
 
 BUNDLED WITH
-   2.1.4
+   2.4.1


### PR DESCRIPTION
This is the current version run on the machine and also resolves the following deprecation warning:

```
Calling `DidYouMean::SPELL_CHECKERS.merge!(error_name => spell_checker)'
has been deprecated. Please call `DidYouMean.correct_error(error_name,
spell_checker)' instead.
```

Related PR: https://github.com/alphagov/govuk-dns/pull/104